### PR TITLE
docs: Update FHERC20 import to use named import and original package

### DIFF
--- a/fhe-library/confidential-contracts/fherc20/overview.mdx
+++ b/fhe-library/confidential-contracts/fherc20/overview.mdx
@@ -217,7 +217,7 @@ Here's a minimal example showing FHERC20 in action:
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
-import "@fhenixprotocol/contracts/FHERC20.sol";
+import { FHERC20 } from "fhenix-confidential-contracts/contracts/FHERC20.sol";
 
 contract MyConfidentialToken is FHERC20 {
     constructor() FHERC20("My Confidential Token", "MCT", 18) {}


### PR DESCRIPTION
## Description
This PR updates the Quick Start code example in the FHERC20 overview documentation to point to the correct npm package.

### Changes made:
*   **Updated Package Reference:** Changed the import from `@fhenixprotocol/contracts` to `fhenix-confidential-contracts`.
*   **Switched to Named Imports:** Changed the global import (`import "@fhenixprotocol/contracts/FHERC20.sol"`) to a explicit named import (`import { FHERC20 } from "fhenix-confidential-contracts/contracts/FHERC20.sol"`). 
