### PR TITLE
drop stale cancun requirement from foundry docs

### DIFF
--- a/client-sdk/foundry-plugin/getting-started.mdx
+++ b/client-sdk/foundry-plugin/getting-started.mdx
@@ -66,16 +66,18 @@ test = "test"
 script = "script"
 libs = ["node_modules"]
 solc_version = "0.8.25"     # cofhe-contracts target
-evm_version = "cancun"      # MockACL uses tstore/tload
 auto_detect_remappings = false
 code_size_limit = 100000    # mocks exceed 24 KB
 ```
 
 <Warning>
-- `evm_version = "cancun"` is required — `MockACL` uses transient storage (`tstore`/`tload`) opcodes.
 - `code_size_limit = 100000` is required — the mock contracts exceed the EIP-170 24 KB ceiling.
 - `solc_version = "0.8.25"` matches the compiler used by `@fhenixprotocol/cofhe-contracts`.
 </Warning>
+
+<Note>
+`evm_version = "cancun"` is no longer required as of `@cofhe/mock-contracts@0.5.0` — `MockACL` was migrated off transient storage (`tstore`/`tload`) to block-number-based storage, and the pragma was lowered to `>=0.8.19`. Set it only if your own contracts need cancun-specific opcodes.
+</Note>
 
 </Step>
 

--- a/client-sdk/quick-start/foundry.mdx
+++ b/client-sdk/quick-start/foundry.mdx
@@ -47,15 +47,17 @@ test = "test"
 script = "script"
 libs = ["node_modules"]
 solc_version = "0.8.25"
-evm_version = "cancun"
 auto_detect_remappings = false
 code_size_limit = 100000
 ```
 
 <Warning>
-- `evm_version = "cancun"` is required — `MockACL` uses transient storage opcodes.
-- `code_size_limit = 100000` is required — the mock contracts exceed the EIP-170 24 KB limit.
+`code_size_limit = 100000` is required — the mock contracts exceed the EIP-170 24 KB limit.
 </Warning>
+
+<Note>
+`evm_version = "cancun"` is no longer required as of `@cofhe/mock-contracts@0.5.0` — `MockACL` was migrated off transient storage to block-number-based storage. Set it only if your own contracts need cancun-specific opcodes.
+</Note>
 
 ## 3. Configure `remappings.txt`
 

--- a/client-sdk/reference/foundry-reference.mdx
+++ b/client-sdk/reference/foundry-reference.mdx
@@ -107,11 +107,14 @@ All produce signed `EncryptedInput` shapes signed for `account()`.
 ```toml
 [profile.default]
 solc_version = "0.8.25"     # cofhe-contracts target
-evm_version = "cancun"      # MockACL uses tstore/tload
 auto_detect_remappings = false
 code_size_limit = 100000    # mocks exceed 24 KB
 libs = ["node_modules"]
 ```
+
+<Note>
+`evm_version = "cancun"` is no longer required as of `@cofhe/mock-contracts@0.5.0` — `MockACL` was migrated off transient storage to block-number-based storage. Set it only if your own contracts need cancun-specific opcodes.
+</Note>
 
 ## `remappings.txt` (canonical shape)
 


### PR DESCRIPTION
## Summary

`@cofhe/mock-contracts@0.5.0` migrated `MockACL` off transient storage (`tstore`/`tload`) to block-number-based storage and lowered the pragma to `>=0.8.19`, so `evm_version = "cancun"` is no longer required by the mocks. The Foundry docs still tell users it's mandatory and cite the old rationale, which contradicts the current mock contracts.

This is the first item (gap **A-1**) from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11) (\`Documentation check\`).

## Changes

Updated three Foundry-related pages so they agree with the current mocks:

- \`client-sdk/foundry-plugin/getting-started.mdx\` — drop \`evm_version = "cancun"\` from the recommended \`foundry.toml\`; remove the matching \`<Warning>\` bullet; add a \`<Note>\` explaining when users may still want to set it.
- \`client-sdk/quick-start/foundry.mdx\` — same treatment in the quick-start config block.
- \`client-sdk/reference/foundry-reference.mdx\` — same treatment in the \`foundry.toml requirements\` reference snippet.

\`solc_version = "0.8.25"\` and \`code_size_limit = 100000\` are left in place; both are still load-bearing.

## Verified against

- \`@cofhe/mock-contracts@0.5.0\` changelog ([\`50bb3e4\`](https://github.com/FhenixProtocol/cofhesdk/commit/)) — "Replaced transient storage (\`tstore\`/\`tload\`) in \`MockACL.sol\` with block-number-based storage, removing the EVM \`cancun\` requirement and lowering the Solidity pragma to \`>=0.8.19\`."
- Current \`MockACL.sol\` source — pragma \`>=0.8.19 <0.9.0\`; no \`tstore\`/\`tload\` in any mock contract.
- The plugin's own \`packages/foundry-plugin/foundry.toml\` does **not** pin \`evm_version\` either.

## Out of scope (intentional)

- \`client-sdk/examples/templates.mdx\` describes the contents of the [\`cofhe-foundry-starter\`](https://github.com/FhenixProtocol/cofhe-foundry-starter) repo, not the canonical recommended config. If the starter still ships \`evm_version = "cancun"\` in its \`foundry.toml\`, the docs description is still accurate. Leaving it for a separate starter-repo update.
- \`client-sdk/quick-start/hardhat.mdx\` references \`evmVersion: 'cancun'\` for Hardhat. The rationale there is "transient storage opcodes used by FHE contracts" (not the mocks specifically), and I have not verified whether any user-imported \`@fhenixprotocol/cofhe-contracts\` Solidity still requires cancun on the Hardhat side. Tracked as a separate followup.

## Test plan

- [ ] \`mint dev\` renders \`client-sdk/foundry-plugin/getting-started\`, \`client-sdk/quick-start/foundry\`, and \`client-sdk/reference/foundry-reference\` with no broken layout or stray bullets.
- [ ] Sanity-check on a fresh Foundry project: following the updated config, \`forge build\` and \`forge test\` succeed against \`@cofhe/mock-contracts@^0.5.1\` with no \`evm_version\` set (Forge default).