### PR TITLE
bump @cofhe/* version pins to 0.5.2

### DIFF
--- a/client-sdk/foundry-plugin/getting-started.mdx
+++ b/client-sdk/foundry-plugin/getting-started.mdx
@@ -31,15 +31,15 @@ The plugin and its dependencies are distributed via npm. Install them as dev dep
 <CodeGroup>
 
 ```bash npm
-npm install -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+npm install -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 ```
 
 ```bash pnpm
-pnpm add -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+pnpm add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 ```
 
 ```bash yarn
-yarn add -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+yarn add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 ```
 
 </CodeGroup>
@@ -127,8 +127,8 @@ Known-aligned tuple as of writing:
 
 | Package | Version |
 | --- | --- |
-| `@cofhe/foundry-plugin` | `0.5.1` |
-| `@cofhe/mock-contracts` | `0.5.1` |
+| `@cofhe/foundry-plugin` | `0.5.2` |
+| `@cofhe/mock-contracts` | `0.5.2` |
 | `@fhenixprotocol/cofhe-contracts` | `0.1.3` |
 
 See the [Compatibility](/get-started/introduction/compatibility) page for the canonical table.

--- a/client-sdk/introduction/installation.mdx
+++ b/client-sdk/introduction/installation.mdx
@@ -14,26 +14,26 @@ description: "Install and configure @cofhe/sdk for your project"
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+npm install @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 ```bash pnpm
-pnpm add @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+pnpm add @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 ```bash yarn
-yarn add @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+yarn add @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 </CodeGroup>
 
 | Package | Version | Purpose |
 | --- | --- | --- |
-| `@cofhe/sdk` | `^0.5.1` | Client-side encryption, decryption, and permit management |
+| `@cofhe/sdk` | `^0.5.2` | Client-side encryption, decryption, and permit management |
 | `@fhenixprotocol/cofhe-contracts` | `^0.1.3` | `FHE.sol` — the Solidity library imported by your contracts |
 
 <Note>
-`@fhenixprotocol/cofhe-contracts@0.1.3` requires `@cofhe/sdk` version `>= 0.5.1`.
+`@fhenixprotocol/cofhe-contracts@0.1.3` requires `@cofhe/sdk` version `>= 0.5.1`. Latest published is `0.5.2`.
 </Note>
 
 ## For Hardhat projects
@@ -43,23 +43,23 @@ If you are using Hardhat for development and testing, also install the plugin:
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/hardhat-plugin@^0.5.1 @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+npm install @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 ```bash pnpm
-pnpm add @cofhe/hardhat-plugin@^0.5.1 @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+pnpm add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 ```bash yarn
-yarn add @cofhe/hardhat-plugin@^0.5.1 @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+yarn add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 </CodeGroup>
 
 | Package | Version | Purpose |
 | --- | --- | --- |
-| `@cofhe/hardhat-plugin` | `^0.5.1` | Extends Hardhat with `hre.cofhe`, deploys mock contracts automatically |
-| `@cofhe/sdk` | `^0.5.1` | Client-side encryption, decryption, and permit management |
+| `@cofhe/hardhat-plugin` | `^0.5.2` | Extends Hardhat with `hre.cofhe`, deploys mock contracts automatically |
+| `@cofhe/sdk` | `^0.5.2` | Client-side encryption, decryption, and permit management |
 | `@fhenixprotocol/cofhe-contracts` | `^0.1.3` | `FHE.sol` — the Solidity library imported by your contracts |
 
 See the [Hardhat Plugin Getting Started](/client-sdk/hardhat-plugin/getting-started) guide for configuration details.
@@ -71,17 +71,17 @@ If you are using Foundry for development and testing, install the Foundry plugin
 <CodeGroup>
 
 ```bash npm
-npm install -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+npm install -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash pnpm
-pnpm add -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+pnpm add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash yarn
-yarn add -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+yarn add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
@@ -89,8 +89,8 @@ forge install foundry-rs/forge-std
 
 | Package | Version | Purpose |
 | --- | --- | --- |
-| `@cofhe/foundry-plugin` | `^0.5.1` | `CofheTest` and `CofheClient` — Solidity test base and per-user SDK shim |
-| `@cofhe/mock-contracts` | `^0.5.1` | Mock CoFHE contracts used by the Foundry plugin |
+| `@cofhe/foundry-plugin` | `^0.5.2` | `CofheTest` and `CofheClient` — Solidity test base and per-user SDK shim |
+| `@cofhe/mock-contracts` | `^0.5.2` | Mock CoFHE contracts used by the Foundry plugin |
 | `@fhenixprotocol/cofhe-contracts` | `^0.1.3` | `FHE.sol` — the Solidity library imported by your contracts |
 
 <Note>

--- a/client-sdk/quick-start/foundry.mdx
+++ b/client-sdk/quick-start/foundry.mdx
@@ -21,17 +21,17 @@ The plugin and its CoFHE dependencies are distributed via npm. Install them as d
 <CodeGroup>
 
 ```bash npm
-npm install -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+npm install -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash pnpm
-pnpm add -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+pnpm add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash yarn
-yarn add -D @cofhe/foundry-plugin@^0.5.1 @cofhe/mock-contracts@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+yarn add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 

--- a/client-sdk/quick-start/hardhat.mdx
+++ b/client-sdk/quick-start/hardhat.mdx
@@ -20,15 +20,15 @@ Want to skip the setup? Clone the [cofhe-hardhat-starter](https://github.com/Fhe
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/hardhat-plugin@^0.5.1 @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+npm install @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 ```bash pnpm
-pnpm add @cofhe/hardhat-plugin@^0.5.1 @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+pnpm add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 ```bash yarn
-yarn add @cofhe/hardhat-plugin@^0.5.1 @cofhe/sdk@^0.5.1 @fhenixprotocol/cofhe-contracts@^0.1.3
+yarn add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
 ```
 
 </CodeGroup>

--- a/client-sdk/quick-start/javascript.mdx
+++ b/client-sdk/quick-start/javascript.mdx
@@ -16,15 +16,15 @@ Connect to an FHE-enabled contract, encrypt a value, send it on-chain, and decry
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/sdk@^0.5.1 viem
+npm install @cofhe/sdk@^0.5.2 viem
 ```
 
 ```bash pnpm
-pnpm add @cofhe/sdk@^0.5.1 viem
+pnpm add @cofhe/sdk@^0.5.2 viem
 ```
 
 ```bash yarn
-yarn add @cofhe/sdk@^0.5.1 viem
+yarn add @cofhe/sdk@^0.5.2 viem
 ```
 
 </CodeGroup>

--- a/client-sdk/reference/foundry-reference.mdx
+++ b/client-sdk/reference/foundry-reference.mdx
@@ -133,8 +133,8 @@ hardhat/=node_modules/forge-std/src/
 
 | Package | Version |
 | --- | --- |
-| `@cofhe/foundry-plugin` | `0.5.1` |
-| `@cofhe/mock-contracts` | `0.5.1` |
+| `@cofhe/foundry-plugin` | `0.5.2` |
+| `@cofhe/mock-contracts` | `0.5.2` |
 | `@fhenixprotocol/cofhe-contracts` | `0.1.3` |
 
 See the [Compatibility](/get-started/introduction/compatibility) page for the canonical table.

--- a/get-started/introduction/compatibility.mdx
+++ b/get-started/introduction/compatibility.mdx
@@ -18,11 +18,11 @@ The following table lists all core CoFHE components with their current and minim
 | Component | Current Version | Minimum Compatible Version | Notes |
 |-----------|----------------|----------------------------|-------|
 | **@fhenixprotocol/cofhe-contracts** | [`0.1.3`](https://github.com/FhenixProtocol/cofhe-contracts/tree/v0.1.3) | `0.1.3` | Solidity libraries and smart contracts for FHE operations |
-| **@cofhe/sdk** | [`0.5.1`](https://github.com/FhenixProtocol/cofhesdk/releases/tag/v0.5.1) | `0.5.1` | JavaScript library for interacting with FHE contracts and the CoFHE coprocessor |
-| **@cofhe/hardhat-plugin** | [`0.5.1`](https://github.com/FhenixProtocol/cofhe-hardhat-plugin/releases/tag/v0.5.1) | `0.5.1` | Hardhat plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/hardhat-3-plugin** | `0.5.1` | `0.5.1` | Hardhat 3 plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/foundry-plugin** | `0.5.1` | `0.5.1` | Foundry plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/mock-contracts** | `0.5.1` | `0.5.1` | Mock contracts for local development and testing |
+| **@cofhe/sdk** | [`0.5.2`](https://github.com/FhenixProtocol/cofhesdk/releases/tag/v0.5.2) | `0.5.2` | JavaScript library for interacting with FHE contracts and the CoFHE coprocessor |
+| **@cofhe/hardhat-plugin** | `0.5.2` | `0.5.2` | Hardhat plugin that deploys mock contracts and exposes utilities |
+| **@cofhe/hardhat-3-plugin** | `0.5.2` | `0.5.2` | Hardhat 3 plugin that deploys mock contracts and exposes utilities |
+| **@cofhe/foundry-plugin** | `0.5.2` | `0.5.2` | Foundry plugin that deploys mock contracts and exposes utilities |
+| **@cofhe/mock-contracts** | `0.5.2` | `0.5.2` | Mock contracts for local development and testing |
 
 ## Additional Packages
 
@@ -80,5 +80,3 @@ If you're experiencing issues after updating versions, check the release notes f
 - Review the [Quick Start guide](/fhe-library/introduction/quick-start) to set up your development environment
 - Learn about [best practices](/fhe-library/introduction/best-practices) for developing with CoFHE
 - Explore the [API reference](/api-reference/introduction) for detailed component documentation
-
-e


### PR DESCRIPTION
## Summary

`@cofhe/sdk@0.5.2` and all sibling packages were published, but the docs still pin `^0.5.1` everywhere. Bump install snippets, version tables, and compatibility entries to the latest matching tuple. Also remove a stray trailing `e` character at the end of `compatibility.mdx`.

This is **A-2 + A-3 + A-4 + the trailing-`e` polish item** from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11).

## Where the underlying change was made

- `@cofhe/sdk@0.5.2` release — [cofhesdk CHANGELOG `0.5.2`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/CHANGELOG.md#052) (changeset [`2fbb918`](https://github.com/FhenixProtocol/cofhesdk/commit/2fbb918)).
- The sibling packages (`@cofhe/react`, `@cofhe/hardhat-plugin`, `@cofhe/hardhat-3-plugin`, `@cofhe/foundry-plugin`, `@cofhe/mock-contracts`, `@cofhe/abi`) are version-locked to the SDK via the changesets pipeline — all also at `0.5.2`.

## Changes

| File | What changed |
| --- | --- |
| `get-started/introduction/compatibility.mdx` | Bump all `@cofhe/*` rows from `0.5.1` → `0.5.2`. Delete trailing stray `e`. |
| `client-sdk/introduction/installation.mdx` | Bump `^0.5.1` → `^0.5.2` across all 3 install snippet groups and the per-package tables. Update the `>= 0.5.1` note to mention `0.5.2` is the latest. |
| `client-sdk/foundry-plugin/getting-started.mdx` | Bump install snippets and the "Known-aligned tuple" table to `0.5.2`. |
| `client-sdk/quick-start/javascript.mdx` | Bump install snippets to `^0.5.2`. |
| `client-sdk/quick-start/hardhat.mdx` | Bump install snippets to `^0.5.2`. |
| `client-sdk/quick-start/foundry.mdx` | Bump install snippets to `^0.5.2`. |
| `client-sdk/reference/foundry-reference.mdx` | Bump the version-pinning table to `0.5.2`. |

`@fhenixprotocol/cofhe-contracts` stays at `0.1.3` — no new tag.

## Test plan

- [ ] \`mint dev\` renders all changed pages with the new version strings.
- [ ] Spot-check a fresh \`npm install\` against the updated commands.