### PR TITLE
document onPoll and set404RetryTimeout on decrypt builders

### DIFF
--- a/client-sdk/guides/decrypt-to-tx.mdx
+++ b/client-sdk/guides/decrypt-to-tx.mdx
@@ -100,6 +100,45 @@ Overrides the account used to resolve the active/stored permit.
 
 Overrides the chain used to resolve the Threshold Network URL and permits.
 
+### `.onPoll(callback)` — optional
+
+Register a callback that fires once per poll attempt while `decryptForTx` waits for the Threshold Network to return the plaintext. Useful for surfacing progress in a UI.
+
+```typescript
+const decryptResult = await client
+  .decryptForTx(ctHash)
+  .withoutPermit()
+  .onPoll(({ operation, requestId, attemptIndex, elapsedMs, intervalMs, timeoutMs }) => {
+    console.log(`[${operation}] attempt ${attemptIndex} after ${elapsedMs}ms (next in ${intervalMs}ms, budget ${timeoutMs}ms)`);
+  })
+  .execute();
+```
+
+The callback receives:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `operation` | `'decrypt' \| 'sealoutput'` | Which Threshold Network flow is polling. For `decryptForTx` this is always `'decrypt'`. |
+| `requestId` | `string` | The Threshold Network request id. **May be the empty string** during submit-time retries — see `.set404RetryTimeout(...)` below. |
+| `attemptIndex` | `number` | Zero-based poll attempt counter. |
+| `elapsedMs` | `number` | Time since the first submit attempt. |
+| `intervalMs` | `number` | Delay until the next poll. |
+| `timeoutMs` | `number` | Overall budget shared by submit-retries and status-polling. |
+
+### `.set404RetryTimeout(timeoutMs)` — optional
+
+Configures how long `decryptForTx` keeps retrying when the Threshold Network's submit endpoint responds with `404 Not Found` before a `requestId` is available. This typically happens on slower backends where the ciphertext isn't visible yet at submit time. Defaults to `10_000` ms.
+
+```typescript
+const decryptResult = await client
+  .decryptForTx(ctHash)
+  .withoutPermit()
+  .set404RetryTimeout(20_000) // give a slower backend more time
+  .execute();
+```
+
+Pass `0` to disable submit-time retries (`404` becomes a hard failure). Submit retries share the same overall timeout budget as status polling, so a larger value here trades poll time for submit-recovery time.
+
 ## Common pitfalls
 
 - **Permit mode must be selected**: you must call exactly one of `.withPermit(...)` or `.withoutPermit()` before `.execute()`.

--- a/client-sdk/guides/decrypt-to-view.mdx
+++ b/client-sdk/guides/decrypt-to-view.mdx
@@ -112,6 +112,43 @@ Overrides the account used to resolve the active/stored permit.
 
 Overrides the chain used to resolve the Threshold Network URL and permits.
 
+### `.onPoll(callback)` — optional
+
+Register a callback that fires once per poll attempt while `decryptForView` waits for the Threshold Network to return the sealed plaintext. Useful for surfacing decrypt progress in a UI.
+
+```typescript
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint64)
+  .onPoll(({ operation, requestId, attemptIndex, elapsedMs, intervalMs, timeoutMs }) => {
+    console.log(`[${operation}] attempt ${attemptIndex} after ${elapsedMs}ms (next in ${intervalMs}ms, budget ${timeoutMs}ms)`);
+  })
+  .execute();
+```
+
+The callback receives:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `operation` | `'decrypt' \| 'sealoutput'` | Which Threshold Network flow is polling. For `decryptForView` this is `'sealoutput'`. |
+| `requestId` | `string` | The Threshold Network request id. **May be the empty string** during submit-time retries — see `.set404RetryTimeout(...)` below. |
+| `attemptIndex` | `number` | Zero-based poll attempt counter. |
+| `elapsedMs` | `number` | Time since the first submit attempt. |
+| `intervalMs` | `number` | Delay until the next poll. |
+| `timeoutMs` | `number` | Overall budget shared by submit-retries and status-polling. |
+
+### `.set404RetryTimeout(timeoutMs)` — optional
+
+Configures how long `decryptForView` keeps retrying when the Threshold Network's submit endpoint responds with `404 Not Found` before a `requestId` is available. This typically happens on slower backends where the ciphertext isn't visible yet at submit time. Defaults to `10_000` ms.
+
+```typescript
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint32)
+  .set404RetryTimeout(20_000) // give a slower backend more time
+  .execute();
+```
+
+Pass `0` to disable submit-time retries (`404` becomes a hard failure). Submit retries share the same overall timeout budget as status polling.
+
 ## Common UI patterns
 
 <CodeGroup>


### PR DESCRIPTION
## Summary

Two decrypt-builder additions shipped in `@cofhe/sdk` are not in the docs:

- `.onPoll(callback)` — added in `0.5.0`. Fires once per poll attempt while the Threshold Network resolves a decrypt / sealoutput, with `{ operation, requestId, attemptIndex, elapsedMs, intervalMs, timeoutMs }`.
- `.set404RetryTimeout(timeoutMs)` — added in `0.5.2`. Configures the submit-time `404` retry window (default `10_000` ms). Submit retries share the same overall timeout budget as status polling.

This covers gaps **B-2** and **B-3** from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11).

## Where the underlying changes were made

| Change | Version | Source |
| --- | --- | --- |
| `onPoll` callback on decrypt builders + React | `@cofhe/sdk@0.5.0` | [cofhesdk CHANGELOG `0.5.0` — \`788a6e2\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/CHANGELOG.md#050) · builder defn: [\`packages/sdk/core/decrypt/decryptForTxBuilder.ts#L132-L141\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/core/decrypt/decryptForTxBuilder.ts) · type defn: [\`packages/sdk/core/types.ts#L392-L401\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/core/types.ts) |
| Submit retries on `204 No Content` (with empty \`requestId\`) emit \`onPoll\` | `@cofhe/sdk@0.5.0` | [cofhesdk CHANGELOG `0.5.0` — \`6c4084f\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/CHANGELOG.md#050) |
| `set404RetryTimeout` + submit-time `404` retries | `@cofhe/sdk@0.5.2` | [cofhesdk CHANGELOG `0.5.2` — \`2fbb918\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/CHANGELOG.md#052) (changelog explicitly says: "Update the decryption docs to explain submit-time `404` retries, empty `requestId` values during request creation, and when to increase the retry timeout for slower backends.") |

## Changes

| File | What changed |
| --- | --- |
| `client-sdk/guides/decrypt-to-tx.mdx` | Added `.onPoll(callback)` and `.set404RetryTimeout(timeoutMs)` rows to Builder API. Each includes a code sample, the callback payload table, and the empty-\`requestId\` caveat. |
| `client-sdk/guides/decrypt-to-view.mdx` | Same two methods, scoped to the view flow (`operation` is `'sealoutput'`). |

Existing builder method order (`.execute` → `.withPermit` → `.withoutPermit` → `.setAccount` → `.setChainId`) is preserved; the new methods are appended after `.setChainId`.

## Test plan

- [ ] \`mint dev\` renders both decrypt guides without layout regressions.
- [ ] Eyeball the payload table renders correctly (table inside a section heading).