### PR TITLE
document mocksDeployVerbosity hardhat plugin option

### DIFF
--- a/client-sdk/hardhat-plugin/getting-started.mdx
+++ b/client-sdk/hardhat-plugin/getting-started.mdx
@@ -62,11 +62,22 @@ import '@cofhe/hardhat-plugin';
 export default {
   solidity: '0.8.28',
   cofhe: {
-    logMocks: true,    // log FHE ops to the console (default: true)
-    gasWarning: true,  // warn when mock gas usage is high (default: true)
+    logMocks: true,                 // log FHE ops to the console (default: true)
+    gasWarning: true,               // warn when mock gas usage is high (default: true)
+    mocksDeployVerbosity: 'v',      // mock deployment log verbosity (default: 'v')
   },
 };
 ```
+
+`mocksDeployVerbosity` controls how much output the plugin prints while deploying the mock contracts at the start of each `npx hardhat test` / `npx hardhat node` run:
+
+| Value | Output |
+| --- | --- |
+| `''` | Silent — no deploy lines. |
+| `'v'` | Single summary line per mock (default since `0.5.0`). |
+| `'vv'` | Full per-contract deployment log, including each contract's deployed address. |
+
+This is independent of `logMocks`, which controls **runtime** FHE-op logging (printed when your tests actually call `FHE.*`).
 
 ## Pre-configured networks
 


### PR DESCRIPTION
## Summary

`@cofhe/hardhat-plugin@0.5.0` added a `mocksDeployVerbosity` config option that controls how loud the plugin is while deploying mocks at the start of `npx hardhat test` / `npx hardhat node`. The default also flipped to `'v'` (one summary line per mock) instead of the previous full per-contract dump. None of this is in the docs.

This covers gap **B-6** from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11).

## Where the underlying change was made

- `@cofhe/hardhat-plugin@0.5.0` — [cofhesdk CHANGELOG `0.5.0` — \`f78beb7\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/hardhat-plugin/CHANGELOG.md#050). The changelog entry: *"`mocksDeployVerbosity` config option added to both Hardhat plugins: `''` — silent, `'v'` — single summary line (new default), `'vv'` — full per-contract deployment logs (previous default behavior)."*
- Type defn: [\`packages/hardhat-plugin/src/deploy.ts#L29\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/hardhat-plugin/src/deploy.ts) — \`export type LogMocksDeploy = '' | 'v' | 'vv';\`
- Default wiring: [\`packages/hardhat-plugin/src/index.ts#L190\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/hardhat-plugin/src/index.ts) — \`mocksDeployVerbosity: (userConfig.cofhe?.mocksDeployVerbosity ?? 'v') as LogMocksDeploy\`

## Changes

| File | What changed |
| --- | --- |
| \`client-sdk/hardhat-plugin/getting-started.mdx\` | Added \`mocksDeployVerbosity: 'v'\` to the Configuration example, then a small table documenting the three values (\`''\` / \`'v'\` / \`'vv'\`). Added a one-liner clarifying this is independent of \`logMocks\` (which controls FHE-op runtime logging). |

The existing \`logging.mdx\` page covers **runtime** FHE-op logging only — `mocksDeployVerbosity` is a deploy-time setting, so it belongs in `getting-started.mdx`'s Configuration section, not in `logging.mdx`.

## Out of scope (intentional)

- The `logMocks: true ... (default: true)` line in the same Configuration block contradicts the plugin source (which defaults to `false` — see [\`src/index.ts#L188\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/hardhat-plugin/src/index.ts)). I left it alone here because it's a separate bug, not part of B-6.

## Test plan

- [ ] \`mint dev\` renders \`client-sdk/hardhat-plugin/getting-started\` and the new table inside the Configuration section.
- [ ] Sanity-check that \`cofhe: { mocksDeployVerbosity: '' }\`, \`'v'\`, and \`'vv'\` produce the documented levels of output in a fresh Hardhat project.