### PR TITLE
document permit validation tightening (PermitUtils.validate / ValidationResult)

### DIFF
--- a/client-sdk/guides/error-handling.mdx
+++ b/client-sdk/guides/error-handling.mdx
@@ -78,3 +78,43 @@ try {
   }
 }
 ```
+
+### Distinguishing why a permit is invalid
+
+Since `@cofhe/sdk@0.5.0`, the decrypt flows call `PermitUtils.validate(permit)` internally before talking to the Threshold Network. That helper enforces **schema + signed + not-expired** all at once, so when it fails the recovery path depends on **which** check tripped.
+
+Use the non-throwing `ValidationUtils.isValid` helper from `@cofhe/sdk/permits` to pre-flight the active permit and route based on the typed reason — this avoids the thrown error path entirely:
+
+```typescript
+import { FheTypes } from '@cofhe/sdk';
+import { ValidationUtils } from '@cofhe/sdk/permits';
+
+const active = client.permits.getActivePermit();
+const result = active
+  ? ValidationUtils.isValid(active)
+  : { valid: false, error: 'not-signed' as const };
+
+if (!result.valid) {
+  switch (result.error) {
+    case 'expired':
+      await client.permits.getOrCreateSelfPermit(); // create a fresh one
+      break;
+    case 'not-signed':
+      await client.permits.getOrCreateSelfPermit(); // prompt the wallet to sign
+      break;
+    case 'invalid-schema':
+      client.permits.removeActivePermit(); // stored payload is malformed
+      break;
+  }
+}
+
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint32)
+  .execute();
+```
+
+`ValidationResult.error` is the typed union `'invalid-schema' | 'expired' | 'not-signed' | null` — see [Permits → Validating permits](/client-sdk/guides/permits#validating-permits) for the full helper surface.
+
+<Note>
+If you prefer the throwing path: `PermitUtils.validate(permit)` raises plain `Error`s with messages `Permit is expired` / `Permit is not signed` (or a Zod schema error). These are not wrapped in `CofheError`, so use `err.message` rather than an error code to branch.
+</Note>

--- a/client-sdk/guides/permits.mdx
+++ b/client-sdk/guides/permits.mdx
@@ -249,6 +249,63 @@ client.permits.removePermit(permitHash);
 client.permits.removeActivePermit();
 ```
 
+## Validating permits
+
+Since `@cofhe/sdk@0.5.0`, `PermitUtils.validate` enforces the **full** check: schema + signed + not-expired. The decrypt flows (`decryptForView`, `decryptForTx` with `.withPermit(...)`) call this for you and surface failures as typed errors — you only need to validate manually when you want to inspect or filter permits before using them.
+
+### Throwing helpers — `PermitUtils.*`
+
+| Function | What it checks | Behavior on failure |
+| --- | --- | --- |
+| `PermitUtils.validate(permit)` | Schema **and** signed **and** not-expired. | Throws (`Permit is expired` / `Permit is not signed` / schema error). |
+| `PermitUtils.validateSchema(permit)` | Schema only (shape + invariants). | Throws on schema failure; does **not** check expiry or signatures. |
+
+Use `validateSchema` when you've just received a permit from the wire (e.g. an imported sharing permit) and want to reject malformed payloads without yet caring about expiry.
+
+```typescript
+import { PermitUtils } from '@cofhe/sdk/permits';
+
+try {
+  PermitUtils.validate(permit);
+  // permit is schema-valid, signed, and not expired
+} catch (err) {
+  // err.message is "Permit is expired" / "Permit is not signed" / a Zod schema error
+}
+```
+
+### Non-throwing helpers — `ValidationUtils.*`
+
+For inspection without exception handling, use the `ValidationUtils` helpers. They return a typed `ValidationResult`:
+
+```typescript
+import { ValidationUtils } from '@cofhe/sdk/permits';
+
+const result = ValidationUtils.isValid(permit);
+
+result.valid;  // boolean
+result.error;  // 'invalid-schema' | 'expired' | 'not-signed' | null
+```
+
+| Function | Returns | Use case |
+| --- | --- | --- |
+| `ValidationUtils.isValid(permit)` | `ValidationResult` | Full check (schema + signed + not-expired) without throwing. |
+| `ValidationUtils.isSignedAndNotExpired(permit)` | `ValidationResult` | Skip the schema parse if you already validated the shape. |
+| `ValidationUtils.isSigned(permit)` | `boolean` | "Does it carry a signature on the issuer / recipient side as appropriate?" |
+| `ValidationUtils.isExpired(permit)` | `boolean` | Compare `permit.expiration` to current time. |
+
+<Tip>
+Pattern-match on `result.error` to render a precise UI message:
+
+```typescript
+switch (ValidationUtils.isValid(permit).error) {
+  case 'expired':         return 'This permit has expired — please re-sign.';
+  case 'not-signed':      return 'Permit is awaiting signature.';
+  case 'invalid-schema':  return 'Imported permit is malformed.';
+  case null:              return null;
+}
+```
+</Tip>
+
 ## Persistence and security
 
 - The SDK persists permits in a store keyed by `chainId + account`.


### PR DESCRIPTION
## Summary

`@cofhe/sdk@0.5.0` tightened permit validation: `PermitUtils.validate` now enforces **schema + signed + not-expired** in one call, and `PermitUtils.validateSchema` is the new schema-only helper. The non-throwing `ValidationUtils.isValid` returns a `ValidationResult` whose `error` field is the typed union `'invalid-schema' | 'expired' | 'not-signed' | null`. None of this is in the permits guide or the error-handling guide.

This covers gap **B-4** from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11).

## Where the underlying change was made

- `@cofhe/sdk@0.5.0` — [cofhesdk CHANGELOG `0.5.0` — \`9a06012\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/CHANGELOG.md#050). Direct quote: *"SDK: `PermitUtils.validate` now enforces schema + signed + not-expired (use `PermitUtils.validateSchema` for schema-only validation). SDK: `ValidationResult.error` is now a typed union (`'invalid-schema' | 'expired' | 'not-signed' | null`)."*
- `PermitUtils` defn: [\`packages/sdk/permits/permit.ts#L218-L247\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/permits/permit.ts)
- `ValidationUtils` defn: [\`packages/sdk/permits/validation.ts#L254-L327\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/permits/validation.ts)
- `ValidationResult` type: [\`packages/sdk/permits/types.ts#L190-L192\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/permits/types.ts)

## Changes

| File | What changed |
| --- | --- |
| `client-sdk/guides/permits.mdx` | New "Validating permits" section before "Persistence and security". Documents both the throwing `PermitUtils.*` helpers (`validate`, `validateSchema`) and the non-throwing `ValidationUtils.*` helpers (`isValid`, `isSignedAndNotExpired`, `isSigned`, `isExpired`). Includes a `switch (result.error)` UI-message pattern. |
| `client-sdk/guides/error-handling.mdx` | New "Distinguishing why a permit is invalid" subsection under "Decryption errors". Shows pre-flighting the active permit with `ValidationUtils.isValid`, branching on `result.error`, and a `<Note>` clarifying that the throwing `PermitUtils.validate` path raises plain `Error`s (not `CofheError`). |

## Accuracy notes

- The existing error-handling table lists `PermitInvalid` as an error code. That code does **not** exist in `CofheErrorCode` (see [\`packages/sdk/core/error.ts#L1-L45\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/core/error.ts) — the real permit codes are `InvalidPermitData`, `InvalidPermitDomain`, `PermitNotFound`, `CannotRemoveLastPermit`). I did **not** fix that table row in this PR to keep the diff focused on B-4; flagging as a separate followup.
- `PermitUtils.validate` throws plain `Error` (not `CofheError`), so the example uses the non-throwing pre-flight pattern. The `<Note>` at the end of the new subsection makes the throwing-path behavior explicit.

## Test plan

- [ ] \`mint dev\` renders both pages with the new sections.
- [ ] Verify the cross-link `permits#validating-permits` resolves to the new anchor.