### PR TITLE
document TaskManager isEnabled / onlyIfEnabled switch

### DIFF
--- a/deep-dive/cofhe-components/task-manager.mdx
+++ b/deep-dive/cofhe-components/task-manager.mdx
@@ -43,3 +43,24 @@ The signed message is a fixed **76-byte** buffer:
 | `ct_hash` | 32 bytes | uint256, big-endian |
 
 The message is hashed with `keccak256` and verified using OpenZeppelin's `ECDSA.tryRecover`. The `enc_type` and `chain_id` are derived on-chain, binding each signature to a specific ciphertext type and chain.
+
+## Enable / Disable Switch
+
+The TaskManager carries a global `isEnabled` flag that owner-only `enable()` / `disable()` calls flip. While disabled, every entry point gated by `onlyIfEnabled` reverts with `CofheIsUnavailable` — including `publishDecryptResult` and `publishDecryptResultBatch`. Read access (`getDecryptResultSafe`, `verifyDecryptResultSafe`, etc.) is **not** gated and continues to work.
+
+| Element | Description |
+|---------|-------------|
+| `isEnabled` | Public `bool` state variable. Source of truth for whether the coprocessor accepts new operations on this chain. |
+| `onlyIfEnabled` modifier | Wraps every state-changing FHE-op entry point and `publishDecryptResult*`. Reverts with `CofheIsUnavailable` when `isEnabled == false`. |
+| `enable()` | Owner-only. Sets `isEnabled = true`. |
+| `disable()` | Owner-only. Sets `isEnabled = false` — useful for emergency pause or coordinated upgrades. |
+
+### Reading the flag from a client
+
+Apps can pre-flight the switch before submitting transactions:
+
+```solidity
+bool live = ITaskManager(TASK_MANAGER_ADDRESS).isEnabled();
+```
+
+For React apps using `@cofhe/react`, the [`useCofheEnabled`](/client-sdk/quick-start/react) hook wraps this read and reflects the result reactively — handy for showing a "CoFHE temporarily unavailable" banner without forcing users to fire a doomed transaction first.


### PR DESCRIPTION
## Summary

The TaskManager has had a global `isEnabled` flag since the v0.1.x line, gated via the `onlyIfEnabled` modifier. While disabled, every state-changing FHE-op entry point and `publishDecryptResult*` reverts with `CofheIsUnavailable`. None of this is in the deep-dive page, so apps building reactive UIs around the coprocessor can't find it.

Adding this also gives the React docs (gap B-1 — separate PR) a stable target to cross-link to from `useCofheEnabled`.

This covers gap **B-7** from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11).

## Where the underlying changes were made

- `isEnabled` state variable + `onlyIfEnabled` modifier + `enable()` / `disable()` owner functions, plus the `onlyIfEnabled` gate on publish: [\`cofhe-contracts/contracts/internal/host-chain/contracts/TaskManager.sol#L237-L263\`](https://github.com/FhenixProtocol/cofhe-contracts/blob/master/contracts/internal/host-chain/contracts/TaskManager.sol). The `onlyIfEnabled` modifier on `publishDecryptResult*` was introduced as part of the v0.1.0 publish/verify work — [cofhe-contracts CHANGELOG `v0.1.0`](https://github.com/FhenixProtocol/cofhe-contracts/blob/master/CHANGELOG.md#v010---2025-02-25) — and remains on the current `publishDecryptResult` entry points in the source above.
- React-side mirror — `useCofheEnabled` hook added in `@cofhe/react@0.5.0`: [cofhesdk CHANGELOG `0.5.0` — \`09bf7c9\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/react/CHANGELOG.md#050).

## Changes

| File | What changed |
| --- | --- |
| `deep-dive/cofhe-components/task-manager.mdx` | New "Enable / Disable Switch" section at the bottom of the page. Documents the `isEnabled` state variable, the `onlyIfEnabled` modifier, the owner-only `enable()` / `disable()` functions, the `CofheIsUnavailable` revert, and the client-side read pattern (including a forward reference to `useCofheEnabled` for React apps). |

The `useCofheEnabled` cross-link currently points at the React quick-start stub. Once the React docs PR (gap B-1) lands, the link can be updated to the proper hook reference page.

## Test plan

- [ ] \`mint dev\` renders the new section under the existing Decrypt Result Signature Verification block.
- [ ] Verify the table formatting matches the existing "Key State" / "Functions" tables earlier in the page.