### PR TITLE
FHE.sol reference: wrapE* migration note + batch typed overloads

### DIFF
--- a/fhe-library/reference/fhe-sol/decryption.mdx
+++ b/fhe-library/reference/fhe-sol/decryption.mdx
@@ -39,7 +39,17 @@ FHE.publishDecryptResult(encryptedBid, bidPlaintext, bidSignature);
 
 ### publishDecryptResultBatch
 
-Publishes multiple results in a single call. Typed overloads exist for all encrypted types.
+Publishes multiple results in a single call. Typed overloads exist for every encrypted type:
+
+| Handle array type | Result array type |
+| --- | --- |
+| `ebool[]` | `bool[]` |
+| `euint8[]` | `uint8[]` |
+| `euint16[]` | `uint16[]` |
+| `euint32[]` | `uint32[]` |
+| `euint64[]` | `uint64[]` |
+| `euint128[]` | `uint128[]` |
+| `eaddress[]` | `address[]` |
 
 ```solidity
 euint64[] memory handles = new euint64[](2);
@@ -56,6 +66,10 @@ sigs[1] = sig2;
 
 FHE.publishDecryptResultBatch(handles, values, sigs);
 ```
+
+<Note>
+The compiler resolves the overload from the handle array's element type. There is also a "raw" overload that takes `uint256[]` ctHashes if you only have raw handles to hand.
+</Note>
 
 ---
 
@@ -89,7 +103,7 @@ if (valid) {
 
 ### verifyDecryptResultBatch
 
-Verifies multiple signatures in a single call. Reverts if any is invalid.
+Verifies multiple signatures in a single call. Returns `true` only if every entry is valid; reverts if any signature fails to recover (consistent with the single-entry `verifyDecryptResult`). Typed overloads exist for every encrypted type — same handle/result type table as [`publishDecryptResultBatch`](#publishdecryptresultbatch).
 
 ```solidity
 bool allValid = FHE.verifyDecryptResultBatch(handles, values, sigs);
@@ -97,11 +111,15 @@ bool allValid = FHE.verifyDecryptResultBatch(handles, values, sigs);
 
 ### verifyDecryptResultBatchSafe
 
-Returns a `bool[]` indicating which entries are valid instead of reverting.
+Returns a `bool[]` indicating which entries are valid instead of reverting. Typed overloads cover every encrypted type — same handle/result type table as [`publishDecryptResultBatch`](#publishdecryptresultbatch).
 
 ```solidity
 bool[] memory results = FHE.verifyDecryptResultBatchSafe(handles, values, sigs);
 ```
+
+<Note>
+The batch verify functions (`verifyDecryptResultBatch`, `verifyDecryptResultBatchSafe`) were added in `cofhe-contracts@v0.1.2`. Earlier versions only exposed the single-entry `verifyDecryptResult` / `verifyDecryptResultSafe`.
+</Note>
 
 ---
 

--- a/fhe-library/reference/fhe-sol/utility.mdx
+++ b/fhe-library/reference/fhe-sol/utility.mdx
@@ -39,6 +39,10 @@ eaddress val = FHE.wrapEaddress(handle);
 Use `wrap` when you have a raw handle from storage or an event and need to convert it back to a typed encrypted value.
 </Tip>
 
+<Note>
+**Renamed in `cofhe-contracts@v0.1.3`.** These functions used to be exposed as `FHE.asEbool(bytes32)`, `FHE.asEuint*(bytes32)`, and `FHE.asEaddress(bytes32)`. They were renamed to `wrap*` to remove a Solidity overload ambiguity with `asEuint*(0)` (where the integer literal `0` could resolve to either the plaintext-trivial-encryption overload or the raw-handle overload). If you're upgrading from `<=0.1.2`, search for `FHE.asE*(<bytes32-value>)` call sites and rewrite them as `FHE.wrap*`.
+</Note>
+
 ## Random Number Generation
 
 Generate random encrypted values. An optional `securityZone` parameter is supported.


### PR DESCRIPTION
## Summary

Two `cofhe-contracts` releases changed the surface area documented on the FHE.sol reference pages, but the doc text didn't move:

- **v0.1.2** added `verifyDecryptResultBatch` / `verifyDecryptResultBatchSafe` view functions plus typed `publishDecryptResultBatch` overloads per encrypted type.
- **v0.1.3** renamed `FHE.asEbool(bytes32)` / `asEuint*(bytes32)` / `asEaddress(bytes32)` → `wrapEbool` / `wrapEuint*` / `wrapEaddress` to fix an overload ambiguity with `asEuintX(0)`.

The current docs document `wrapE*` (good), but don't say it replaces the older `asE*(bytes32)` overloads, and the batch verify/publish examples only show the un-typed call shape.

This covers gaps **B-9** and **B-10** from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11).

## Where the underlying changes were made

- **v0.1.3 `wrapE*` rename** — [cofhe-contracts CHANGELOG `v0.1.3`](https://github.com/FhenixProtocol/cofhe-contracts/blob/master/CHANGELOG.md#v013---2025-03-25). Direct quote: *"Rename `FHE.asEbool(bytes32)`, `FHE.asEuint*(bytes32)`, `FHE.asEaddress(bytes32)` to `FHE.wrapEbool(bytes32)`, `FHE.wrapEuint*(bytes32)`, `FHE.wrapEaddress(bytes32)` to avoid overload ambiguity with `asEuintX(0)` calls and clarify intent."*
- **v0.1.2 batch verify + typed overloads** — [cofhe-contracts CHANGELOG `v0.1.2`](https://github.com/FhenixProtocol/cofhe-contracts/blob/master/CHANGELOG.md#v012---2025-03-25-deprecated). Direct quote: *"Add `verifyDecryptResultBatch` and `verifyDecryptResultBatchSafe` to TaskManager (view functions for batch signature verification). Add typed overloads for `publishDecryptResultBatch`, `verifyDecryptResultBatch`, and `verifyDecryptResultBatchSafe` in FHE.sol (per encrypted type: ebool, euint8-128, eaddress)."*
- Typed overload definitions: [\`contracts/FHE.sol#L3362-L3505\`](https://github.com/FhenixProtocol/cofhe-contracts/blob/master/contracts/FHE.sol).
- Base (un-typed) overloads: [\`contracts/FHE.sol#L146-L187\`](https://github.com/FhenixProtocol/cofhe-contracts/blob/master/contracts/FHE.sol).

## Changes

| File | What changed |
| --- | --- |
| `fhe-library/reference/fhe-sol/utility.mdx` | Added a `<Note>` under `## wrap` explaining the v0.1.3 rename from `FHE.asE*(bytes32)` and giving upgrade guidance for callers on `<=0.1.2`. |
| `fhe-library/reference/fhe-sol/decryption.mdx` | Added the typed handle/result type table to `publishDecryptResultBatch` (one row per encrypted type). Cross-referenced the same table from `verifyDecryptResultBatch` and `verifyDecryptResultBatchSafe` (so the table doesn't have to be repeated 3×). Added a `<Note>` saying the batch verify functions were added in v0.1.2. Tightened the `verifyDecryptResultBatch` description to reflect the actual return semantics (`true` iff every entry valid; reverts on signature recovery failure). |

## Test plan

- [ ] \`mint dev\` renders both reference pages with the new tables and notes.
- [ ] Verify the anchor link \`#publishdecryptresultbatch\` resolves correctly when clicked from the verify sections.