### PR TITLE
mark legacy cofhejs pages with deprecation warning

### DIFF
--- a/cofhejs/examples/end-to-end.mdx
+++ b/cofhejs/examples/end-to-end.mdx
@@ -2,6 +2,10 @@
 title: End-to-End Example
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/examples/end-to-end) instead. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 This example demonstrates a full interaction between a dApp and an FHE-enabled smart contract using `cofhejs`. You'll learn how to set up the client, encrypt data, send it to the contract, create a permit for accessing sealed data, and finally unseal the returned data for the user.
 
 ### Prerequisites

--- a/cofhejs/guides/encryption.mdx
+++ b/cofhejs/guides/encryption.mdx
@@ -3,6 +3,10 @@ title: Encryption
 description: "Encrypt input data before sending it to FHE-enabled smart contracts"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/guides/encrypting-inputs) instead. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 ## Encrypting Input Data
 
 This step secures your data before sending it to the smart contract. Remember - all data sent to a smart contract on a blockchain is inherently public, which means that anyone can see it. However, Fhenix operates differently. To maintain user confidentiality and protect sensitive input data, Fhenix utilizes **Cofhejs** to provide built-in encryption methods that you must apply before sending any data to an FHE-enabled contract.

--- a/cofhejs/guides/error-handling.mdx
+++ b/cofhejs/guides/error-handling.mdx
@@ -3,6 +3,10 @@ title: Error Handling
 description: "Handle errors effectively when working with Cofhejs using the Result type pattern"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/guides/error-handling) instead. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 ## Error Handling
 
 `cofhejs` uses a consistent error handling pattern based on the `Result` type to provide predictable and type-safe error handling throughout the library. This guide explains how error handling works and how to properly handle errors in your applications.

--- a/cofhejs/guides/permits-management.mdx
+++ b/cofhejs/guides/permits-management.mdx
@@ -3,6 +3,10 @@ title: Permits Management
 description: "Create and manage permits for accessing encrypted data in FHE-enabled smart contracts"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/guides/permits) instead. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 ## Creating Permits
 
 After encryption, values can be passed into FHE-enabled smart contracts, and the contract can operate on this data securely, within its own logic. However, to ensure that only the respective user can view the processed (encrypted) data, **permissions** and **sealing** mechanisms are used. These ensure that data remains private and viewable exclusively by the user who owns it.

--- a/cofhejs/guides/sealing-unsealing.mdx
+++ b/cofhejs/guides/sealing-unsealing.mdx
@@ -3,6 +3,10 @@ title: Sealing & Unsealing
 description: "Unseal encrypted data returned from FHE-enabled smart contracts"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/guides/decrypt-to-view) instead — sealing/unsealing is handled internally by `decryptForView` / `decryptForTx`. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 ## Overview
 
 In Fhenix's FHE system, data returned from smart contracts is "sealed" (internally re-encrypted since it already exists in an encrypted state) to maintain confidentiality during transmission. The unsealing process converts this encrypted data back into readable values using your permit's sealing key pair.

--- a/cofhejs/introduction/installation.mdx
+++ b/cofhejs/introduction/installation.mdx
@@ -3,6 +3,10 @@ title: Manual Installation
 description: "Install and set up Cofhejs for FHE-enabled smart contract development"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/introduction/installation) instead. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 To get started with Cofhejs, you need to install it as a dependency in your JavaScript project. You can do this using npm (Node Package Manager), Yarn, or pnpm. Open your terminal and navigate to your project's directory, then run the following:
 
 <CodeGroup>

--- a/cofhejs/introduction/mental-model.mdx
+++ b/cofhejs/introduction/mental-model.mdx
@@ -3,6 +3,10 @@ title: Mental Model
 description: "Understand how data flows through FHE-enabled dApps"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/introduction/mental-model) instead. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 To understand how **Cofhejs** fits into the Fhenix framework, you'll explore a simple mental model using a Counter smart contract example. This will show you how data flows through FHE-enabled dApps—from encryption to computation to decryption.
 
 ## The Counter Example

--- a/cofhejs/introduction/overview.mdx
+++ b/cofhejs/introduction/overview.mdx
@@ -3,6 +3,9 @@ title: Overview
 description: "Introduction to Cofhejs - a TypeScript package for interacting with FHE-enabled smart contracts"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/introduction/overview) instead. See [Migrating from cofhejs](/client-sdk/introduction/migrating-from-cofhejs) for a side-by-side guide. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
 
 Cofhejs is a TypeScript package designed to enable seamless interaction between clients and Fhenix's co-processor (CoFHE). It is an essential component for engineers working with FHE-enabled smart contracts, as it facilitates the encryption and decryption processes required for secure data handling in decentralized applications (dApps). Cofhejs ensures that data remains private throughout its journey from input to output in the blockchain ecosystem.
 

--- a/cofhejs/resources/templates.mdx
+++ b/cofhejs/resources/templates.mdx
@@ -3,6 +3,10 @@ title: "Development Templates"
 description: "Ready-to-use templates, tools, and tutorials to accelerate your FHE-enabled dApp development with Cofhejs"
 ---
 
+<Warning>
+**`cofhejs` is the legacy client library.** New projects should use [`@cofhe/sdk`](/client-sdk/examples/templates) instead — see the templates page on the Client SDK tab for the current starter repos. These pages remain for reference for projects that haven't migrated yet.
+</Warning>
+
 ## GitHub Templates
 
 Production-ready code repositories that you can clone and deploy immediately to start building FHE-enabled dApps.


### PR DESCRIPTION
## Summary

`cofhejs` is the legacy client library — superseded by `@cofhe/sdk`, with a full migration guide already at [`/client-sdk/introduction/migrating-from-cofhejs`](https://github.com/FhenixProtocol/fhenix-developer-docs/blob/master/client-sdk/introduction/migrating-from-cofhejs.mdx). The current `cofhejs/*` pages don't say anything about being legacy, so users landing there from search or external links have no idea the API has moved.

This is a minimal-risk fix: add a `<Warning>` callout to the top of every page under the `cofhejs/` tree, pointing at the equivalent `@cofhe/sdk` page and the migration guide. The pages themselves stay (the tab remains in `docs.json`) so existing projects on `cofhejs` aren't stranded.

This covers gap **A-6** from the [docs audit on XDL-11](https://github.com/FhenixProtocol/cofhe/issues/XDL-11).

## Where the underlying change was made

- `cofhejs` was renamed and reshipped as `@cofhe/sdk@0.1.0` — [cofhesdk CHANGELOG `0.1.0` — \`a83facb\` & \`8d41cf2\`](https://github.com/FhenixProtocol/cofhesdk/blob/master/packages/sdk/CHANGELOG.md#010). Direct quote: *"Prepare for initial release. Rename scope from `@cofhesdk` to `@cofhe` and rename `cofhesdk` package to `@cofhe/sdk`."* Every release since has been on the `@cofhe/*` packages; the standalone `cofhejs` package on npm is frozen.

## Changes

Same `<Warning>` block added at the top of all 9 cofhejs pages, with the per-page link aimed at the most relevant `@cofhe/sdk` replacement:

| File | Cross-link target |
| --- | --- |
| `cofhejs/introduction/overview.mdx` | `/client-sdk/introduction/overview` |
| `cofhejs/introduction/installation.mdx` | `/client-sdk/introduction/installation` |
| `cofhejs/introduction/mental-model.mdx` | `/client-sdk/introduction/mental-model` |
| `cofhejs/guides/encryption.mdx` | `/client-sdk/guides/encrypting-inputs` |
| `cofhejs/guides/error-handling.mdx` | `/client-sdk/guides/error-handling` |
| `cofhejs/guides/permits-management.mdx` | `/client-sdk/guides/permits` |
| `cofhejs/guides/sealing-unsealing.mdx` | `/client-sdk/guides/decrypt-to-view` (sealing/unsealing is internal in the new SDK — `decryptForView` / `decryptForTx` handle it) |
| `cofhejs/examples/end-to-end.mdx` | `/client-sdk/examples/end-to-end` |
| `cofhejs/resources/templates.mdx` | `/client-sdk/examples/templates` |

Every Warning also links to `/client-sdk/introduction/migrating-from-cofhejs` for the side-by-side mapping.

## Out of scope (intentional)

- I did **not** remove the `cofhejs` tab from \`docs.json\`. The audit recommended this as a possible follow-up step, but it's a bigger UX call (does the team want to keep the tab visible at all?). The Warning is the lighter, reversible step.

## Test plan

- [ ] \`mint dev\` renders each cofhejs page with the Warning rendered above the original first heading / paragraph.
- [ ] All 9 cross-links resolve to existing client-sdk pages.