### PR TITLE
docs: fix broken Telegram invite link across documentation pages

### DIFF
--- a/get-started/builder-support/get-funded.mdx
+++ b/get-started/builder-support/get-funded.mdx
@@ -8,6 +8,6 @@ description: "Information about funding opportunities for Fhenix builders"
 We're working on exciting funding opportunities and grant programs to support developers building on Fhenix. Check back soon for updates on how to get funded for your FHE-enabled projects.
 
 <Info>
-Stay tuned for announcements about grants, funding programs, and builder support initiatives. Follow our [Discord](https://discord.gg/FuVgxrvJMY) and [Telegram](https://t.me/+237VUa7c6v1jZmFh) channels for the latest updates.
+Stay tuned for announcements about grants, funding programs, and builder support initiatives. Follow our [Discord](https://discord.gg/FuVgxrvJMY) and [Telegram](https://t.me/+OEO4CItQYh8xYzNh) channels for the latest updates.
 </Info>
 

--- a/get-started/introduction/support-and-feedback.mdx
+++ b/get-started/introduction/support-and-feedback.mdx
@@ -65,12 +65,12 @@ Connect with our active community of developers and team members ready to help y
 
 #### Telegram
 
-Connect with us on [Telegram](https://t.me/+237VUa7c6v1jZmFh) for:
+Connect with us on [Telegram](https://t.me/+OEO4CItQYh8xYzNh) for:
 
 - **General** - General discussions
 - **Dev Help** - Technical support and questions
 
-<Card title="Join Telegram" icon="telegram" href="https://t.me/+237VUa7c6v1jZmFh">
+<Card title="Join Telegram" icon="telegram" href="https://t.me/+OEO4CItQYh8xYzNh">
 Get quick answers to your questions and connect with the Fhenix community.
 </Card>
 


### PR DESCRIPTION
Fix incorrect Telegram invite link across documentation pages.

Changes:
- get-started/introduction/support-and-feedback.mdx: replace broken Telegram invite link
  https://t.me/+237VUa7c6v1jZmFh → https://t.me/+OEO4CItQYh8xYzNh
- get-started/builder-support/get-funded.mdx: replace broken Telegram invite link
  https://t.me/+237VUa7c6v1jZmFh → https://t.me/+OEO4CItQYh8xYzNh

Correct link sourced from official fhenix.io website.

Closes #31 

Test plan
Documentation-only change; no code paths affected.