### PR TITLE
Add "From FHE to CoFHE" bridge section to fhenix.mdx

### DIFF
--- a/get-started/introduction/fhenix.mdx
+++ b/get-started/introduction/fhenix.mdx
@@ -60,4 +60,23 @@ These challenges can all be mitigated by using FHE in your smart contracts.
 * Users control their data without relying on trusted third parties.
 
 
+---
+
+## From FHE to CoFHE
+
+FHE establishes that computation on encrypted data is possible — but
+possibility alone doesn't make it practical. Implementing FHE from
+scratch requires deep cryptographic expertise and migrating to an
+entirely different chain. Fhenix solves this by taking a different
+approach: instead of asking developers to migrate, bring encrypted
+computation to the chains they already use.
+
+The result is CoFHE — an FHE coprocessor that attaches to any EVM
+chain. The heavy cryptographic work runs offchain; your contract only
+ever sees lightweight handles to encrypted values. Same Solidity, same
+chains — confidentiality becomes just another feature.
+
+→ See how CoFHE works in practice: [What is CoFHE?](/get-started/introduction/what-is-cofhe)
+
+
 


### PR DESCRIPTION
## Summary

While reviewing the recently merged PR #32, I identified the need 
to add a dedicated **"From FHE to CoFHE"** section to `fhenix.mdx`. 
A reader finishing the page understands FHE as a technology, but has 
no context for why CoFHE exists, how Fhenix arrived at it, or what 
problem it solves beyond FHE itself. A single handoff link would close 
the navigation gap, but wouldn't give the reader enough to understand 
the connection between the two concepts.

The new **"From FHE to CoFHE"** section bridges them meaningfully, 
explaining why FHE alone isn't enough, how Fhenix evolved its approach, 
and what CoFHE actually delivers. As a result, this also closes the 
open follow-up from PR #32:

> "The landing page and `fhenix.mdx` still don't name CoFHE — 
> a one-line handoff link from the FHE intro would close the loop."

## Changes

`fhenix.mdx`: added new section at the end of the file

**Before:** page ends after "What is FHE?" with no mention of CoFHE, 
reader understands the technology but has no path to the product

**After:** new "From FHE to CoFHE" section meaningfully connects 
the FHE concept to the CoFHE product and guides the reader forward

## Test plan
Documentation-only change; no code paths affected.