### PR TITLE
fix(tutorials): make ACL usage examples compile

### DIFF
--- a/tutorials/acl-usage-examples.mdx
+++ b/tutorials/acl-usage-examples.mdx
@@ -23,7 +23,7 @@ The contract that creates the value for the first time will automatically get ow
 
 ```solidity
 // Contract A
-function doAdd(InEuint32 input1, InEuint32 input2) {
+function doAdd(InEuint32 memory input1, InEuint32 memory input2) public {
     euint32 handle1 = FHE.asEuint32(input1); // Contract A gets temporary ownership of handle1
     euint32 handle2 = FHE.asEuint32(input2); // Contract A gets temporary ownership of handle2
     
@@ -41,10 +41,10 @@ To use the results in other transactions, explicit ownership must be granted wit
 
 ```solidity
 contract A {
-    private euint32 result;
-    private euint32 handle1;
+    euint32 private result;
+    euint32 private handle1;
 
-    function doAdd(InEuint32 input1, InEuint32 input2) {
+    function doAdd(InEuint32 memory input1, InEuint32 memory input2) public {
         handle1 = FHE.asEuint32(input1);         // Contract A gets temporary ownership of handle1
         euint32 handle2 = FHE.asEuint32(input2); // Contract A gets temporary ownership of handle2
 
@@ -52,7 +52,7 @@ contract A {
         FHE.allowThis(result);                   // result is allowed for future transactions
     }
 
-    function doSomethingWithResult() {
+    function doSomethingWithResult() public {
         FHE.allowPublic(result);  // Allowed — marks result as publicly decryptable
         FHE.add(handle1, result); // ACLNotAllowed (handle1 is not owned persistently)
     }
@@ -69,9 +69,9 @@ To decrypt a ciphertext off-chain via the decryption network, the issuer must be
 
 ```solidity
 contract A {
-    private mapping(address => euint32) balances;
+    mapping(address => euint32) private balances;
 
-    function transfer(InEuint32 _amount, address to) {
+    function transfer(InEuint32 memory _amount, address to) public {
         euint32 amount = FHE.asEuint32(_amount);
 
         balances[msg.sender] = FHE.sub(balances[msg.sender], amount);
@@ -97,7 +97,7 @@ You can also allow other contracts to use your ciphertexts, either persistently 
 
 ```solidity
 contract A {
-    function doAdd(InEuint32 input1) {
+    function doAdd(InEuint32 memory input1) public {
         euint32 handle1 = FHE.asEuint32(input1);       // Contract A gets temporary ownership of handle1
 
         FHE.allowTransient(handle1, addressB); // Contract B is allowed to use handle1 in this transaction alone
@@ -120,7 +120,7 @@ Use `FHE.allowTransient()` when you only need to grant access for a single trans
 When modifying encrypted values that users need to access:
 
 ```solidity
-function updateBalance(address user, InEuint32 amount) public {
+function updateBalance(address user, InEuint32 memory amount) public {
     euint32 encryptedAmount = FHE.asEuint32(amount);
     balances[user] = FHE.add(balances[user], encryptedAmount);
     
@@ -137,7 +137,7 @@ function updateBalance(address user, InEuint32 amount) public {
 A common pattern is to allow the message sender:
 
 ```solidity
-function submitEncryptedData(InEuint32 data) public {
+function submitEncryptedData(InEuint32 memory data) public {
     euint32 encryptedData = FHE.asEuint32(data);
     storedData[msg.sender] = encryptedData;
     
@@ -151,7 +151,7 @@ function submitEncryptedData(InEuint32 data) public {
 For values that should be accessible to everyone:
 
 ```solidity
-function setPublicValue(InEuint32 value) public onlyOwner {
+function setPublicValue(InEuint32 memory value) public onlyOwner {
     publicValue = FHE.asEuint32(value);
     FHE.allowPublic(publicValue); // Everyone can now access this value
 }


### PR DESCRIPTION

## Problem

All 7 Solidity snippets in `tutorials/acl-usage-examples.mdx` fail to compile.

Verified against `solc 0.8.28` with the real `@fhenixprotocol/cofhe-contracts@0.1.4` package. I extracted each code block from the `.mdx` programmatically (not retyped) and compiled it twice:

- **Verbatim**, exactly as shown on the page: 7/7 fail.

- **With a generous harness** (SPDX, pragma, real `FHE.sol` / `ICofhe.sol` imports, a wrapping contract for bare functions, and the missing state variables the snippets reference): still 7/7 fail.

The second pass matters. It rules out "these are just fragments" as the explanation. The displayed lines themselves are the problem.

## Three error classes

**`ParserError (9182)` — `private` before the type**

8 | private euint32 result;
| ^^^^^^^
Function, variable, struct or modifier declaration expected.

This one aborts parsing, so it was masking further errors in blocks 2 and 3. Fixing just that line surfaced 4 more errors in block 2 and 2 more in block 3.

**`SyntaxError (4937)` — no visibility specifier**

9 | function doAdd(InEuint32 input1, InEuint32 input2) {
| ^ No visibility specified. Did you intend to add "public"?

Required since Solidity 0.5.

**`TypeError (6651)` — missing data location**

9 | function doAdd(InEuint32 input1, InEuint32 input2) {
| ^^^^^^^^^^^^^^^^
Data location must be "memory" or "calldata" for parameter in function, but none was given.

`InEuint32` is a struct (`ICofhe.sol:32`), and the library's own signature is `asEuint32(InEuint32 memory value)`. All 9 parameters across the page were missing this. It's the single issue that hits every block.

## Fix

11 lines, one file. After the change, all 7 blocks compile with the same harness:

PASS Block1_AutoTransient.sol errors=0 warnings=1
PASS Block2_PersistentAllowance.sol errors=0 warnings=0
PASS Block3_AllowanceForDecryptions.sol errors=0 warnings=0
PASS Block4_AllowOtherContracts.sol errors=0 warnings=0
PASS Block5_Pattern1_ContractAndUser.sol errors=0 warnings=0
PASS Block6_Pattern2_AllowSender.sol errors=0 warnings=0
PASS Block7_Pattern3_GlobalAccess.sol errors=0 warnings=0



The remaining warning in block 1 is `Unused local variable` on the `result` line, which looks intentional since that snippet is teaching that the value does not persist. Left alone.

## Scope

Syntax only. **The documented API surface is correct** — `allowThis`, `allow`, `allowTransient`, `allowPublic` and `allowSender` all exist in `cofhe-contracts@0.1.4` (`FHE.sol:3010-3319`). Nothing about the ACL semantics this page teaches is changed.

Deliberately left out, happy to do any of these separately if useful:

- The snippets reference `addressB`, `IContractB`, `balances`, `storedData`, `publicValue` and an `onlyOwner` modifier that are never declared. Making each block self-contained would mean expanding them, which is a bigger editorial call than a syntax fix.

- The "Solidity API" list at lines 16-18 mentions `allowThis` / `allow` / `allowTransient`, but the examples below also use `allowPublic` and `allowSender`.

Happy to adjust anything here.

