### PR TITLE
docs: install instructions pin `^0.5.2`, which cannot resolve to the current 0.6.1 release

### DIFF
--- a/client-sdk/foundry-plugin/getting-started.mdx
+++ b/client-sdk/foundry-plugin/getting-started.mdx
@@ -31,15 +31,15 @@ The plugin and its dependencies are distributed via npm. Install them as dev dep
 <CodeGroup>
 
 ```bash npm
-npm install -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+npm install -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 ```
 
 ```bash pnpm
-pnpm add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+pnpm add -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 ```
 
 ```bash yarn
-yarn add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+yarn add -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 ```
 
 </CodeGroup>
@@ -129,9 +129,9 @@ Known-aligned tuple as of writing:
 
 | Package | Version |
 | --- | --- |
-| `@cofhe/foundry-plugin` | `0.5.2` |
-| `@cofhe/mock-contracts` | `0.5.2` |
-| `@fhenixprotocol/cofhe-contracts` | `0.1.3` |
+| `@cofhe/foundry-plugin` | `0.6.1` |
+| `@cofhe/mock-contracts` | `0.6.1` |
+| `@fhenixprotocol/cofhe-contracts` | `0.1.4` |
 
 See the [Compatibility](/get-started/introduction/compatibility) page for the canonical table.
 

--- a/client-sdk/introduction/installation.mdx
+++ b/client-sdk/introduction/installation.mdx
@@ -14,26 +14,26 @@ description: "Install and configure @cofhe/sdk for your project"
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+npm install @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 ```bash pnpm
-pnpm add @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+pnpm add @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 ```bash yarn
-yarn add @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+yarn add @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 </CodeGroup>
 
 | Package | Version | Purpose |
 | --- | --- | --- |
-| `@cofhe/sdk` | `^0.5.2` | Client-side encryption, decryption, and permit management |
-| `@fhenixprotocol/cofhe-contracts` | `^0.1.3` | `FHE.sol` — the Solidity library imported by your contracts |
+| `@cofhe/sdk` | `^0.6.1` | Client-side encryption, decryption, and permit management |
+| `@fhenixprotocol/cofhe-contracts` | `^0.1.4` | `FHE.sol` — the Solidity library imported by your contracts |
 
 <Note>
-`@fhenixprotocol/cofhe-contracts@0.1.3` requires `@cofhe/sdk` version `>= 0.5.1`. Latest published is `0.5.2`.
+`@cofhe/hardhat-plugin@0.6.1` and `@cofhe/foundry-plugin@0.6.1` pin `@fhenixprotocol/cofhe-contracts` to `0.1.4`. Latest published `@cofhe/*` is `0.6.1`.
 </Note>
 
 ## For Hardhat projects
@@ -43,24 +43,24 @@ If you are using Hardhat for development and testing, also install the plugin:
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+npm install @cofhe/hardhat-plugin@^0.6.1 @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 ```bash pnpm
-pnpm add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+pnpm add @cofhe/hardhat-plugin@^0.6.1 @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 ```bash yarn
-yarn add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+yarn add @cofhe/hardhat-plugin@^0.6.1 @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 </CodeGroup>
 
 | Package | Version | Purpose |
 | --- | --- | --- |
-| `@cofhe/hardhat-plugin` | `^0.5.2` | Extends Hardhat with `hre.cofhe`, deploys mock contracts automatically |
-| `@cofhe/sdk` | `^0.5.2` | Client-side encryption, decryption, and permit management |
-| `@fhenixprotocol/cofhe-contracts` | `^0.1.3` | `FHE.sol` — the Solidity library imported by your contracts |
+| `@cofhe/hardhat-plugin` | `^0.6.1` | Extends Hardhat with `hre.cofhe`, deploys mock contracts automatically |
+| `@cofhe/sdk` | `^0.6.1` | Client-side encryption, decryption, and permit management |
+| `@fhenixprotocol/cofhe-contracts` | `^0.1.4` | `FHE.sol` — the Solidity library imported by your contracts |
 
 See the [Hardhat Plugin Getting Started](/client-sdk/hardhat-plugin/getting-started) guide for configuration details.
 
@@ -71,17 +71,17 @@ If you are using Foundry for development and testing, install the Foundry plugin
 <CodeGroup>
 
 ```bash npm
-npm install -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+npm install -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash pnpm
-pnpm add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+pnpm add -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash yarn
-yarn add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+yarn add -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
@@ -89,9 +89,9 @@ forge install foundry-rs/forge-std
 
 | Package | Version | Purpose |
 | --- | --- | --- |
-| `@cofhe/foundry-plugin` | `^0.5.2` | `CofheTest` and `CofheClient` — Solidity test base and per-user SDK shim |
-| `@cofhe/mock-contracts` | `^0.5.2` | Mock CoFHE contracts used by the Foundry plugin |
-| `@fhenixprotocol/cofhe-contracts` | `^0.1.3` | `FHE.sol` — the Solidity library imported by your contracts |
+| `@cofhe/foundry-plugin` | `^0.6.1` | `CofheTest` and `CofheClient` — Solidity test base and per-user SDK shim |
+| `@cofhe/mock-contracts` | `^0.6.1` | Mock CoFHE contracts used by the Foundry plugin |
+| `@fhenixprotocol/cofhe-contracts` | `^0.1.4` | `FHE.sol` — the Solidity library imported by your contracts |
 
 <Note>
 The Foundry plugin uses Solidity-only abstractions — no `@cofhe/sdk` (JS) needed for tests.

--- a/client-sdk/quick-start/foundry.mdx
+++ b/client-sdk/quick-start/foundry.mdx
@@ -21,17 +21,17 @@ The plugin and its CoFHE dependencies are distributed via npm. Install them as d
 <CodeGroup>
 
 ```bash npm
-npm install -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+npm install -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash pnpm
-pnpm add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+pnpm add -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 
 ```bash yarn
-yarn add -D @cofhe/foundry-plugin@^0.5.2 @cofhe/mock-contracts@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3 @openzeppelin/contracts
+yarn add -D @cofhe/foundry-plugin@^0.6.1 @cofhe/mock-contracts@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4 @openzeppelin/contracts
 forge install foundry-rs/forge-std
 ```
 

--- a/client-sdk/quick-start/hardhat.mdx
+++ b/client-sdk/quick-start/hardhat.mdx
@@ -20,15 +20,15 @@ Want to skip the setup? Clone the [cofhe-hardhat-starter](https://github.com/Fhe
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+npm install @cofhe/hardhat-plugin@^0.6.1 @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 ```bash pnpm
-pnpm add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+pnpm add @cofhe/hardhat-plugin@^0.6.1 @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 ```bash yarn
-yarn add @cofhe/hardhat-plugin@^0.5.2 @cofhe/sdk@^0.5.2 @fhenixprotocol/cofhe-contracts@^0.1.3
+yarn add @cofhe/hardhat-plugin@^0.6.1 @cofhe/sdk@^0.6.1 @fhenixprotocol/cofhe-contracts@^0.1.4
 ```
 
 </CodeGroup>

--- a/client-sdk/quick-start/javascript.mdx
+++ b/client-sdk/quick-start/javascript.mdx
@@ -16,15 +16,15 @@ Connect to an FHE-enabled contract, encrypt a value, send it on-chain, and decry
 <CodeGroup>
 
 ```bash npm
-npm install @cofhe/sdk@^0.5.2 viem
+npm install @cofhe/sdk@^0.6.1 viem
 ```
 
 ```bash pnpm
-pnpm add @cofhe/sdk@^0.5.2 viem
+pnpm add @cofhe/sdk@^0.6.1 viem
 ```
 
 ```bash yarn
-yarn add @cofhe/sdk@^0.5.2 viem
+yarn add @cofhe/sdk@^0.6.1 viem
 ```
 
 </CodeGroup>

--- a/client-sdk/reference/foundry-reference.mdx
+++ b/client-sdk/reference/foundry-reference.mdx
@@ -136,8 +136,8 @@ hardhat/=node_modules/forge-std/src/
 
 | Package | Version |
 | --- | --- |
-| `@cofhe/foundry-plugin` | `0.5.2` |
-| `@cofhe/mock-contracts` | `0.5.2` |
-| `@fhenixprotocol/cofhe-contracts` | `0.1.3` |
+| `@cofhe/foundry-plugin` | `0.6.1` |
+| `@cofhe/mock-contracts` | `0.6.1` |
+| `@fhenixprotocol/cofhe-contracts` | `0.1.4` |
 
 See the [Compatibility](/get-started/introduction/compatibility) page for the canonical table.

--- a/get-started/introduction/compatibility.mdx
+++ b/get-started/introduction/compatibility.mdx
@@ -17,12 +17,12 @@ The following table lists all core CoFHE components with their current and minim
 
 | Component | Current Version | Minimum Compatible Version | Notes |
 |-----------|----------------|----------------------------|-------|
-| **@fhenixprotocol/cofhe-contracts** | [`0.1.3`](https://github.com/FhenixProtocol/cofhe-contracts/tree/v0.1.3) | `0.1.3` | Solidity libraries and smart contracts for FHE operations |
-| **@cofhe/sdk** | [`0.5.2`](https://github.com/FhenixProtocol/cofhesdk/releases/tag/v0.5.2) | `0.5.2` | JavaScript library for interacting with FHE contracts and the CoFHE coprocessor |
-| **@cofhe/hardhat-plugin** | `0.5.2` | `0.5.2` | Hardhat plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/hardhat-3-plugin** | `0.5.2` | `0.5.2` | Hardhat 3 plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/foundry-plugin** | `0.5.2` | `0.5.2` | Foundry plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/mock-contracts** | `0.5.2` | `0.5.2` | Mock contracts for local development and testing |
+| **@fhenixprotocol/cofhe-contracts** | [`0.1.4`](https://github.com/FhenixProtocol/cofhe-contracts/tree/v0.1.4) | `0.1.3` | Solidity libraries and smart contracts for FHE operations |
+| **@cofhe/sdk** | [`0.6.1`](https://github.com/FhenixProtocol/cofhesdk/releases/tag/%40cofhe%2Fsdk%400.6.1) | `0.5.2` | JavaScript library for interacting with FHE contracts and the CoFHE coprocessor |
+| **@cofhe/hardhat-plugin** | `0.6.1` | `0.5.2` | Hardhat plugin that deploys mock contracts and exposes utilities |
+| **@cofhe/hardhat-3-plugin** | `0.6.1` | `0.5.2` | Hardhat 3 plugin that deploys mock contracts and exposes utilities |
+| **@cofhe/foundry-plugin** | `0.6.1` | `0.5.2` | Foundry plugin that deploys mock contracts and exposes utilities |
+| **@cofhe/mock-contracts** | `0.6.1` | `0.5.2` | Mock contracts for local development and testing |
 
 ## Additional Packages
 


### PR DESCRIPTION
## Problem

Every install command and version table in the client-SDK docs pins the CoFHE packages at `^0.5.2` (and `@fhenixprotocol/cofhe-contracts` at `^0.1.3`). All five `@cofhe/*` packages are now published at **0.6.1**, and the contracts package at **0.1.4**.

Because these are `0.x` versions, the caret range is narrower than people expect: `^0.5.2` means `>=0.5.2 <0.6.0`, so it can **never** resolve to 0.6.1. Anyone following the docs installs a full minor line behind, and no warning is produced.

Verified against two independent registry mirrors (jsDelivr and unpkg):

| Package | Docs pin | Latest published |
|---|---|---|
| `@cofhe/sdk` | `^0.5.2` | **0.6.1** |
| `@cofhe/hardhat-plugin` | `^0.5.2` | **0.6.1** |
| `@cofhe/hardhat-3-plugin` | `0.5.2` | **0.6.1** |
| `@cofhe/foundry-plugin` | `^0.5.2` | **0.6.1** |
| `@cofhe/mock-contracts` | `^0.5.2` | **0.6.1** |
| `@fhenixprotocol/cofhe-contracts` | `^0.1.3` | **0.1.4** |

## Fix

Bump the documented ranges to `^0.6.1` / `^0.1.4` across the install commands and version tables.

The contracts bump is required rather than cosmetic: `@cofhe/hardhat-plugin@0.6.1` declares a peer dependency of `@fhenixprotocol/cofhe-contracts >=0.1.4`, and `@cofhe/foundry-plugin@0.6.1` and `@cofhe/mock-contracts@0.6.1` both pin it to exactly `0.1.4`. So the "keep all three aligned" note in the Foundry reference stays true only if the tuple moves together.

Two smaller things ride along, both on lines already being touched:

- `client-sdk/introduction/installation.mdx` stated *"`@fhenixprotocol/cofhe-contracts@0.1.3` requires `@cofhe/sdk` version `>= 0.5.1`. Latest published is `0.5.2`."* — the last sentence is now wrong. Replaced with the pinning relationship I could verify from the published manifests.
- The `@cofhe/sdk` link in the compatibility table pointed at `releases/tag/v0.5.2`, which 404s — this repo tags releases as `@cofhe/sdk@<version>`, not `v<version>`, so that link has never resolved. Repointed at the real 0.6.1 release tag (verified 200).

## Scope note

I deliberately left the **Minimum Compatible Version** column in `compatibility.mdx` untouched. Bumping "current" is a fact I can verify from the registry; deciding the lowest still-supported version is your call, not mine. I also left the historical note in `fhe-library/reference/fhe-sol/utility.mdx` about the rename in `cofhe-contracts@v0.1.3`, since that is a statement about the past.

Docs-only: 7 files, no code or config touched.