### PR TITLE
docs: fix 8 broken internal links pointing at section paths

### DIFF
--- a/client-sdk/introduction/installation.mdx
+++ b/client-sdk/introduction/installation.mdx
@@ -116,5 +116,5 @@ import { Encryptable, FheTypes } from '@cofhe/sdk';
 
 ## Next steps
 
-- [Quick Start](/client-sdk/quick-start) — write your first FHE contract and test
+- [Quick Start](/client-sdk/quick-start/javascript) — write your first FHE contract and test
 - [Client Setup](/client-sdk/guides/client-setup) — configure and connect the SDK client

--- a/client-sdk/introduction/overview.mdx
+++ b/client-sdk/introduction/overview.mdx
@@ -93,7 +93,7 @@ const balance = await client
 
 <CardGroup cols={2}>
 
-<Card title="Quick Start" icon="rocket" href="/client-sdk/quick-start">
+<Card title="Quick Start" icon="rocket" href="/client-sdk/quick-start/javascript">
   Install the SDK, write a contract, and run your first encrypt → store → decrypt test in minutes.
 </Card>
 

--- a/fhe-library/introduction/best-practices.mdx
+++ b/fhe-library/introduction/best-practices.mdx
@@ -202,8 +202,8 @@ By following these best practices, you'll create more secure, efficient, and mai
 
 ## Next Steps
 
-- Learn about [encrypted data types](/fhe-library) and their use cases
-- Explore [FHE operations](/fhe-library) available in the library
-- Review [access control mechanisms](/fhe-library) for managing permissions
-- Check out [common pitfalls](/fhe-library) to avoid
+- Learn about [encrypted data types](/fhe-library/reference/fhe-sol/overview) and their use cases
+- Explore [FHE operations](/fhe-library/core-concepts/encrypted-operations) available in the library
+- Review [access control mechanisms](/fhe-library/core-concepts/access-control) for managing permissions
+- Check out [common pitfalls](/fhe-library/core-concepts/common-errors) to avoid
 

--- a/fhe-library/introduction/quick-start.mdx
+++ b/fhe-library/introduction/quick-start.mdx
@@ -321,10 +321,10 @@ Be aware that FHE operations cost more gas than standard operations. Mock enviro
 
 Now that you have your development environment set up, you can:
 
-- Explore the [FHE Library documentation](/fhe-library) to learn about encrypted data types and operations
+- Explore the [FHE Library documentation](/fhe-library/introduction/overview) to learn about encrypted data types and operations
 - Review the [Counter contract example](https://github.com/FhenixProtocol/cofhe-hardhat-starter/blob/main/contracts/Counter.sol) to see FHE in action
 - Check out the [Client SDK documentation](/client-sdk/introduction/overview) for client-side integration
-- Learn about [access control mechanisms](/fhe-library) for managing encrypted data permissions
+- Learn about [access control mechanisms](/fhe-library/core-concepts/access-control) for managing encrypted data permissions
 
 ## Resources
 


### PR DESCRIPTION
## Problem

Eight internal links point at `/fhe-library` and `/client-sdk/quick-start`. Neither is a page — they are section prefixes. Neither exists as an `.mdx` file, and neither appears as a nav entry in `docs.json`, so all eight 404:

| File | Link text | Target |
| --- | --- | --- |
| [`fhe-library/introduction/best-practices.mdx:205`](fhe-library/introduction/best-practices.mdx#L205) | encrypted data types | `/fhe-library` |
| [`fhe-library/introduction/best-practices.mdx:206`](fhe-library/introduction/best-practices.mdx#L206) | FHE operations | `/fhe-library` |
| [`fhe-library/introduction/best-practices.mdx:207`](fhe-library/introduction/best-practices.mdx#L207) | access control mechanisms | `/fhe-library` |
| [`fhe-library/introduction/best-practices.mdx:208`](fhe-library/introduction/best-practices.mdx#L208) | common pitfalls | `/fhe-library` |
| [`fhe-library/introduction/quick-start.mdx:324`](fhe-library/introduction/quick-start.mdx#L324) | FHE Library documentation | `/fhe-library` |
| [`fhe-library/introduction/quick-start.mdx:327`](fhe-library/introduction/quick-start.mdx#L327) | access control mechanisms | `/fhe-library` |
| [`client-sdk/introduction/overview.mdx:96`](client-sdk/introduction/overview.mdx#L96) | Quick Start (Card) | `/client-sdk/quick-start` |
| [`client-sdk/introduction/installation.mdx:119`](client-sdk/introduction/installation.mdx#L119) | Quick Start | `/client-sdk/quick-start` |

All eight sit in "Next steps" / "What's next" blocks — the exact place a reader clicks after finishing a page, so this is the worst spot for a dead end. `best-practices.mdx` is the clearest case: four consecutive bullets with four different link texts all resolving to the same non-existent path.

## Change

Retargeted each link by its own link text, to the page whose existing title/description already matches — no page was renamed, added, or reworded:

| Link text | New target | Why that page |
| --- | --- | --- |
| encrypted data types | `/fhe-library/reference/fhe-sol/overview` | its description is "Encrypted data types, imports, and general usage of the FHE Solidity library" |
| FHE operations | `/fhe-library/core-concepts/encrypted-operations` | titled "FHE Encrypted Operations" |
| access control mechanisms | `/fhe-library/core-concepts/access-control` | titled "Access Control" |
| common pitfalls | `/fhe-library/core-concepts/common-errors` | titled "Common Errors" |
| FHE Library documentation | `/fhe-library/introduction/overview` | the FHE Library section's own landing page |
| Quick Start (both) | `/client-sdk/quick-start/javascript` | first page of the "Quick Start" nav group in `docs.json` |

Link targets only — 8 lines across 4 files, no prose changes.

## Verification

- Re-ran a scan over every `href="/..."` and `](/...)` across all 113 `.mdx` pages: **no broken internal links remain**.
- All six new targets exist on disk **and** are nav entries in `docs.json` (checked both, since a page can exist without being routed).
- Also swept `docs.json` the other way — every nav entry resolves to a real page, so there is nothing of the #17 kind outstanding.

This is the same class of fix as #15 ("Fix 11 broken internal links across docs") and #17; these eight accumulated after those landed.

## Note on overlap

`client-sdk/introduction/installation.mdx` is also touched by #35, but that PR only edits the version pins around lines 14–40 while this touches line 119, so the two do not conflict. Happy to drop that one file if you would rather keep the PRs fully disjoint.
