### PR TITLE
[DOCS] client-sdk: assertCorrectEncryptedItemInput is not exported by @cofhe/sdk

### DIFF
--- a/client-sdk/guides/writing-encrypted-data.mdx
+++ b/client-sdk/guides/writing-encrypted-data.mdx
@@ -46,7 +46,7 @@ contract EncryptedCounter {
 ```
 
 ```typescript TypeScript (viem)
-import { Encryptable, assertCorrectEncryptedItemInput } from '@cofhe/sdk';
+import { Encryptable } from '@cofhe/sdk';
 import { parseAbi } from 'viem';
 import { sepolia } from 'viem/chains';
 
@@ -58,7 +58,6 @@ const encryptedCounterAbi = parseAbi([
 const [inCount] = await cofheClient
   .encryptInputs([Encryptable.uint32(42n)])
   .execute();
-assertCorrectEncryptedItemInput(inCount);
 
 // 2) Pass the encrypted struct as the InE* argument
 const hash = await walletClient.writeContract({

--- a/client-sdk/guides/writing-encrypted-data.mdx
+++ b/client-sdk/guides/writing-encrypted-data.mdx
@@ -3,9 +3,9 @@ title: Writing Encrypted Data to Contract
 description: "Encrypt plaintext values and pass them directly into a contract call"
 ---
 
-This page covers the "encrypt → write tx" flow: encrypt plaintext values into `InE*` structs and pass them directly into a contract call.
+This page covers the "encrypt, then write tx" flow: encrypt plaintext values into `InE*` structs and pass them directly into a contract call.
 
-`encryptInputs` returns `EncryptedItemInput` objects that match the Solidity `InE*` input structs. The on-chain CoFHE library validates the verifier signature before the contract can use the ciphertext.
+`encryptInputs` returns `EncryptedItemInput` objects that match the Solidity `InE*` input structs. The onchain CoFHE library validates the verifier signature before the contract can use the ciphertext.
 
 ## Flow
 
@@ -20,9 +20,9 @@ This page covers the "encrypt → write tx" flow: encrypt plaintext values into 
 
 The encrypted type you choose in TypeScript must match the Solidity parameter type:
 
-- `Encryptable.uint32(...)` → `InEuint32`
-- `Encryptable.bool(...)` → `InEbool`
-- `Encryptable.address(...)` → `InEaddress`
+- `Encryptable.uint32(...)` maps to `InEuint32`
+- `Encryptable.bool(...)` maps to `InEbool`
+- `Encryptable.address(...)` maps to `InEaddress`
 
 ## Example: encrypt and call a contract
 

--- a/client-sdk/reference/sdk-reference.mdx
+++ b/client-sdk/reference/sdk-reference.mdx
@@ -11,7 +11,7 @@ This page is under construction. A full API reference documenting all functions,
 
 | Entrypoint | Contents |
 | --- | --- |
-| `@cofhe/sdk` | Core types: `Encryptable`, `FheTypes`, `EncryptStep`, `CofheError`, `CofheErrorCode`, `isCofheError`, `assertCorrectEncryptedItemInput` |
+| `@cofhe/sdk` | Core types: `Encryptable`, `FheTypes`, `EncryptStep`, `CofheError`, `CofheErrorCode`, `isCofheError` |
 | `@cofhe/sdk/web` | `createCofheConfig`, `createCofheClient` (browser defaults) |
 | `@cofhe/sdk/node` | `createCofheConfig`, `createCofheClient` (Node.js defaults) |
 | `@cofhe/sdk/permits` | `PermitUtils`, `setPermit`, `setActivePermitHash`, `getPermit`, `getActivePermitHash` |


### PR DESCRIPTION
`assertCorrectEncryptedItemInput` does not exist in `@cofhe/sdk`. It is not exported from the package, and there is no declaration for it anywhere in the source or the built types, so the viem snippet on the writing-encrypted-data page fails at the import line before it can run.

The ethers snippet directly below it on the same page does the same thing without the assertion, importing only `Encryptable`, so the two examples disagreed with each other as well.

Commits, one page each:

- writing-encrypted-data: narrowed the import to `Encryptable` and dropped the call
- sdk-reference: removed the name from the `@cofhe/sdk` entrypoint row
- writing-encrypted-data: brought the page in line with STYLE.md, since the repo asks for that on any page a change touches. That is the three arrows in the prose and one `on-chain`, all predating the style linter.

Checked the other six names in that entrypoint row and they are all real exports. `scripts/lint-docs.py` reports 0 errors on both pages, and I checked both against the error-level Vale rules as well.
