### PR TITLE
docs(client-sdk): migrate permit API docs to ACP for @cofhe/sdk 0.7

### DIFF
--- a/client-sdk/examples/end-to-end.mdx
+++ b/client-sdk/examples/end-to-end.mdx
@@ -1,9 +1,9 @@
 ---
 title: End-to-End Example
-description: "A complete encrypt → store → decrypt flow using @cofhe/sdk"
+description: "A complete encrypt, store, and decrypt flow using @cofhe/sdk"
 ---
 
-This example demonstrates the full lifecycle of working with encrypted data: initialize the SDK, encrypt a value, send it to a contract, and decrypt the result — both for UI display and for on-chain verification.
+This example demonstrates the full lifecycle of working with encrypted data: initialize the SDK, encrypt a value, send it to a contract, and decrypt the result, both for UI display and for onchain verification.
 
 ## The contract
 
@@ -67,8 +67,8 @@ const walletClient = createWalletClient({
 
 await client.connect(publicClient, walletClient);
 
-// 2. Create a permit
-await client.permits.getOrCreateSelfPermit();
+// 2. Create an ACP
+await client.acp.getOrCreateSelfACP();
 
 // 3. Encrypt and deposit
 const [encryptedAmount] = await client
@@ -88,10 +88,10 @@ const balance = await client
 
 console.log('Balance:', balance); // 100n
 
-// 5. Decrypt for on-chain verification
+// 5. Decrypt for onchain verification
 const { decryptedValue, signature } = await client
   .decryptForTx(ctHash)
-  .withPermit()
+  .withACP()
   .execute();
 
 await contract.publishBalance(ctHash, decryptedValue, signature);
@@ -116,8 +116,8 @@ const client = createCofheClient(config);
 const { publicClient, walletClient } = await Ethers6Adapter(provider, wallet);
 await client.connect(publicClient, walletClient);
 
-// 2. Create a permit
-await client.permits.getOrCreateSelfPermit();
+// 2. Create an ACP
+await client.acp.getOrCreateSelfACP();
 
 // 3. Encrypt and deposit
 const [encryptedAmount] = await client
@@ -134,10 +134,10 @@ const balance = await client
 
 console.log('Balance:', balance); // 100n
 
-// 5. Decrypt for on-chain verification
+// 5. Decrypt for onchain verification
 const { decryptedValue, signature } = await client
   .decryptForTx(ctHash)
-  .withPermit()
+  .withACP()
   .execute();
 
 await contract.publishBalance(ctHash, decryptedValue, signature);
@@ -175,7 +175,7 @@ describe('ConfidentialVault', () => {
     expect(balance).to.equal(100n);
   });
 
-  it('publishes a decrypt result on-chain', async () => {
+  it('publishes a decrypt result onchain', async () => {
     const Factory = await hre.ethers.getContractFactory('ConfidentialVault');
     const vault = await Factory.deploy();
 
@@ -185,14 +185,14 @@ describe('ConfidentialVault', () => {
       .execute();
     await (await vault.deposit(encrypted)).wait();
 
-    // Decrypt for on-chain verification
+    // Decrypt for onchain verification
     const ctHash = await vault.getBalance();
     const { decryptedValue, signature } = await cofheClient
       .decryptForTx(ctHash)
-      .withPermit()
+      .withACP()
       .execute();
 
-    // Publish on-chain with Threshold Network proof
+    // Publish onchain with Threshold Network proof
     await (await vault.publishBalance(ctHash, decryptedValue, signature)).wait();
   });
 });

--- a/client-sdk/examples/templates.mdx
+++ b/client-sdk/examples/templates.mdx
@@ -50,5 +50,5 @@ forge test -vvv
 - `foundry.toml` with `evm_version = "cancun"`, `solc_version = "0.8.25"`, and `code_size_limit = 100000`
 - `remappings.txt` configured for the plugin and mocks
 - A sample `Counter` contract using FHE
-- Tests demonstrating `expectPlaintext`, `decryptForTx_withoutPermit`, permit-based unseal, ACL deny assertions, and fuzz tests
+- Tests demonstrating `expectPlaintext`, `decryptForTx_withoutACP`, ACP-based unseal, ACL deny assertions, and fuzz tests
 - Deploy scripts for `eth-sepolia`, `arb-sepolia`, and `base-sepolia`

--- a/client-sdk/foundry-plugin/cofhe-client.mdx
+++ b/client-sdk/foundry-plugin/cofhe-client.mdx
@@ -1,9 +1,9 @@
 ---
 title: CofheClient
-description: "The in-Solidity SDK shim — one client per user, produces encrypted inputs and signed permits"
+description: "The in-Solidity SDK shim: one client per user, produces encrypted inputs and signed ACPs"
 ---
 
-`CofheClient` is the Foundry plugin's in-Solidity SDK shim. One client per "user" in your scenario. The client carries a private key and produces encrypted inputs / signed permits **as if it were that user's frontend SDK** — no JS bridge required.
+`CofheClient` is the Foundry plugin's in-Solidity SDK shim. One client per "user" in your scenario. The client carries a private key and produces encrypted inputs / signed ACPs **as if it were that user's frontend SDK**, with no JS bridge required.
 
 ## Creating and connecting
 
@@ -14,9 +14,9 @@ CofheClient bob = createCofheClient();
 bob.connect(0xB0B);            // bob.account() == vm.addr(0xB0B)
 ```
 
-After `connect`, the client knows which address to sign as. All `createInEuintN` and `permit_*` calls use that account automatically — there's no `account` argument to pass.
+After `connect`, the client knows which address to sign as. All `createInEuintN` and `ACP_*` calls use that account automatically; there's no `account` argument to pass.
 
-To act on-chain as that user, prank with `client.account()`:
+To act onchain as that user, prank with `client.account()`:
 
 ```solidity
 vm.prank(bob.account());
@@ -24,12 +24,12 @@ counter.reset(bob.createInEuint32(2000));
 ```
 
 <Warning>
-A mismatch between the prank address and the client that produced the input will fail the ZK-verifier signature check — the input was signed for `bob.account()`, not whoever you pranked. Always match the client to the prank.
+A mismatch between the prank address and the client that produced the input will fail the ZK-verifier signature check: the input was signed for `bob.account()`, not whoever you pranked. Always match the client to the prank.
 </Warning>
 
 ## Encrypting inputs
 
-The client mirrors the JS SDK's `encryptInputs` API — one method per encrypted Solidity type:
+The client mirrors the JS SDK's `encryptInputs` API: one method per encrypted Solidity type:
 
 | Method | Returns |
 | --- | --- |
@@ -41,7 +41,7 @@ The client mirrors the JS SDK's `encryptInputs` API — one method per encrypted
 | `createInEuint128(uint128)` | `InEuint128` |
 | `createInEaddress(address)` | `InEaddress` |
 
-All produce signed `EncryptedInput` shapes — drop straight into the `InEuintN` parameter on the contract under test.
+All produce signed `EncryptedInput` shapes: drop straight into the `InEuintN` parameter on the contract under test.
 
 ```solidity
 InEuint32 memory encrypted = bob.createInEuint32(42);
@@ -56,11 +56,11 @@ The plugin exposes both decryption flows the SDK supports:
 
 | Method | Returns | Use for |
 | --- | --- | --- |
-| `decryptForTx_withoutPermit(ctHash)` | `(bytes32 ctHash, uint256 plaintext, bytes signature)` | Globally-allowed (`FHE.allowPublic`) ciphertexts. Pass `signature` to `FHE.publishDecryptResult`. |
-| `decryptForTx_withPermit(ctHash, permit)` | `(bytes32, uint256, bytes)` | ACL-gated `decryptForTx` flow. |
-| `decryptForView(ctHash, permit)` | `uint256 plaintext` | Off-chain seal/unseal flow. **Reverts on deny** — use the mock directly to assert deny. |
+| `decryptForTx_withoutACP(ctHash)` | `(bytes32 ctHash, uint256 plaintext, bytes signature)` | Globally allowed (`FHE.allowPublic`) ciphertexts. Pass `signature` to `FHE.publishDecryptResult`. |
+| `decryptForTx_withACP(ctHash, acp)` | `(bytes32, uint256, bytes)` | ACL-gated `decryptForTx` flow. |
+| `decryptForView(ctHash, acp)` | `uint256 plaintext` | Offchain seal/unseal flow. **Reverts on deny**: use the mock directly to assert deny. |
 
-### `decryptForTx_withoutPermit` — public-decrypt 3-step flow
+### `decryptForTx_withoutACP`: public-decrypt 3-step flow
 
 Mirrors the production flow when a contract calls `FHE.publishDecryptResult`:
 
@@ -71,65 +71,65 @@ counter.allowCounterPublicly();   // calls FHE.allowPublic(handle)
 
 // Step 2: SDK fetches plaintext + threshold-network signature
 bytes32 ctHash = euint32.unwrap(counter.count());
-(, uint256 plaintext, bytes memory sig) = bob.decryptForTx_withoutPermit(ctHash);
+(, uint256 plaintext, bytes memory sig) = bob.decryptForTx_withoutACP(ctHash);
 
 // Step 3: contract verifies signature and stores plaintext
 counter.revealCounter(uint32(plaintext), sig);
 ```
 
-The same shape runs unmodified against real CoFHE on testnet — the mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
+The same shape runs unmodified against real CoFHE on testnet: the mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
 
-### `decryptForView` — permit-based unseal
+### `decryptForView`: ACP-based unseal
 
 ```solidity
-Permission memory bobPermit = bob.permit_createSelf();
-uint256 value = bob.decryptForView(ctHash, bobPermit);
+ACP memory bobAcp = bob.ACP_createSelf();
+uint256 value = bob.decryptForView(ctHash, bobAcp);
 assertEq(value, 42);
 ```
 
-`decryptForView` reverts when the caller isn't on the ACL. To **assert** the deny path (e.g. "Alice should NOT be able to decrypt Bob's value"), drop down to the mock directly — see [Testing: Deny path](/client-sdk/foundry-plugin/testing#deny-path-asserting-alice-cannot-decrypt-bob-s-value).
+`decryptForView` reverts when the caller isn't on the ACL. To **assert** the deny path (for example "Alice should NOT be able to decrypt Bob's value"), drop down to the mock directly. See [Testing: Deny path](/client-sdk/foundry-plugin/testing#deny-path-asserting-alice-cannot-decrypt-bob-s-value).
 
-## Permits
+## ACPs
 
-The client signs EIP-712 permits against the ACL's domain. Two flavors:
+The client signs EIP-712 ACPs against the ACL's domain. Two flavors:
 
 | Method | Purpose |
 | --- | --- |
-| `permit_createSelf()` | Self-permit for the connected account; sealing key is auto-derived (`keccak(address)`). |
-| `permit_createShared(recipient)` | Issuer half of a shared permit (no sealing key — the recipient adds it on import). |
-| `permit_exportShared(perm)` | Strip sensitive fields → `SharedPermitExport` (safe to transmit out-of-band). |
-| `permit_importShared(export)` | Recipient-side completion: adds sealing key + recipient signature. Reverts unless `export.recipient == account()`. |
-| `createSealingKey(seed)` | Custom sealing key. Rarely needed — `permit_createSelf` derives one for you. |
+| `ACP_createSelf()` | Self ACP for the connected account; sealing key is auto-derived (`keccak(address)`). |
+| `ACP_createShared(recipient)` | Issuer half of a shared ACP (no sealing key: the recipient adds it on import). |
+| `ACP_exportShared(acp)` | Strip sensitive fields to `SharedACPExport` (safe to transmit out-of-band). |
+| `ACP_importShared(export)` | Recipient-side completion: adds sealing key + recipient signature. Reverts unless `export.recipient == account()`. |
+| `createSealingKey(seed)` | Custom sealing key. Rarely needed: `ACP_createSelf` derives one for you. |
 
-### Self-permit (most common)
+### Self ACP (most common)
 
 ```solidity
-Permission memory bobPermit = bob.permit_createSelf();
-uint256 plaintext = bob.decryptForView(ctHash, bobPermit);
+ACP memory bobAcp = bob.ACP_createSelf();
+uint256 plaintext = bob.decryptForView(ctHash, bobAcp);
 ```
 
-`permit_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs — all in one call.
+`ACP_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs, all in one call.
 
-### Shared permits (issuer → recipient)
+### Shared ACPs (issuer to recipient)
 
 ```solidity
-// Bob (issuer) creates a permit shared to Alice (recipient)
-Permission memory shared = bob.permit_createShared(alice.account());
+// Bob (issuer) creates an ACP shared to Alice (recipient)
+ACP memory shared = bob.ACP_createShared(alice.account());
 
 // Bob exports it (strips bob's sealing key) for transmission
-SharedPermitExport memory exported = bob.permit_exportShared(shared);
+SharedACPExport memory exported = bob.ACP_exportShared(shared);
 
-// Alice imports it — adds her sealing key and recipient signature
-Permission memory aliceImported = alice.permit_importShared(exported);
+// Alice imports it: adds her sealing key and recipient signature
+ACP memory aliceImported = alice.ACP_importShared(exported);
 ```
 
-`permit_importShared` reverts unless the calling client's `account()` matches `export.recipient` — preventing Alice from importing a permit shared to someone else.
+`ACP_importShared` reverts unless the calling client's `account()` matches `export.recipient`, preventing Alice from importing an ACP shared to someone else.
 
 ## Common pitfalls
 
 <AccordionGroup>
 <Accordion title="Wrong client for the prank" icon="triangle-exclamation">
-`vm.prank(bob.account())` while the input came from `alice.createInEuintN(...)` fails ZK verification — the input was signed for Alice's address, not Bob's. Match the client to the prank.
+`vm.prank(bob.account())` while the input came from `alice.createInEuintN(...)` fails ZK verification: the input was signed for Alice's address, not Bob's. Match the client to the prank.
 </Accordion>
 
 <Accordion title="Stale handle reads" icon="rotate">
@@ -146,16 +146,16 @@ expectPlaintext(counter.count(), uint32(1));   // ✅ fetch the new handle
 Re-fetch after each state change.
 </Accordion>
 
-<Accordion title="Permit issuer must derive from the connected key" icon="key">
-The `pkey` passed to `connect` must derive the address used as `permit.issuer`. If you call `bob.permit_createSelf()` after `bob.connect(0xB0B)`, the issuer is `vm.addr(0xB0B)`. Trying to forge an issuer mismatch will fail signature verification.
+<Accordion title="ACP issuer must derive from the connected key" icon="key">
+The `pkey` passed to `connect` must derive the address used as `acp.issuer`. If you call `bob.ACP_createSelf()` after `bob.connect(0xB0B)`, the issuer is `vm.addr(0xB0B)`. Trying to forge an issuer mismatch will fail signature verification.
 </Accordion>
 
 <Accordion title="`decryptForView` reverts on deny" icon="ban">
-Useful default — most tests want a hard failure when the caller isn't permitted. To assert "Alice cannot decrypt", call the mock's `querySealOutput` directly:
+Useful default: most tests want a hard failure when the caller isn't permitted. To assert "Alice cannot decrypt", call the mock's `querySealOutput` directly:
 
 ```solidity
 (bool allowed, string memory err, ) = mockThresholdNetwork.querySealOutput(
-    uint256(ctHash), block.chainid, alicePermit
+    uint256(ctHash), block.chainid, aliceAcp
 );
 assertFalse(allowed);
 assertEq(err, "NotAllowed");
@@ -165,5 +165,5 @@ assertEq(err, "NotAllowed");
 
 ## Next steps
 
-- [Testing](/client-sdk/foundry-plugin/testing) — full test-writing patterns.
-- [CofheTest](/client-sdk/foundry-plugin/cofhe-test) — the test base contract that creates clients.
+- [Testing](/client-sdk/foundry-plugin/testing): full test-writing patterns.
+- [CofheTest](/client-sdk/foundry-plugin/cofhe-test): the test base contract that creates clients.

--- a/client-sdk/foundry-plugin/getting-started.mdx
+++ b/client-sdk/foundry-plugin/getting-started.mdx
@@ -3,7 +3,7 @@ title: Getting Started
 description: "Set up @cofhe/foundry-plugin for local FHE contract development and testing under Forge"
 ---
 
-`@cofhe/foundry-plugin` is the Foundry counterpart to [`@cofhe/hardhat-plugin`](/client-sdk/hardhat-plugin/getting-started). It provides two abstract Solidity contracts — `CofheTest` (test base, deploys all CoFHE mocks) and `CofheClient` (per-account encrypt/decrypt/permit shim) — that let you exercise FHE contracts under `forge test` with **no JS SDK required**.
+`@cofhe/foundry-plugin` is the Foundry counterpart to [`@cofhe/hardhat-plugin`](/client-sdk/hardhat-plugin/getting-started). It provides two abstract Solidity contracts, `CofheTest` (test base, deploys all CoFHE mocks) and `CofheClient` (per-account encrypt/decrypt/ACP shim), that let you exercise FHE contracts under `forge test` with **no JS SDK required**.
 
 <Tip>
 Want to skip the setup? Clone the [cofhe-foundry-starter](https://github.com/FhenixProtocol/cofhe-foundry-starter) template to get a pre-configured project ready to go.
@@ -11,9 +11,9 @@ Want to skip the setup? Clone the [cofhe-foundry-starter](https://github.com/Fhe
 
 ## What the plugin provides
 
-- **`CofheTest`** — abstract test base that inherits `forge-std/Test` and deploys the full CoFHE mock stack (`MockTaskManager`, `MockACL`, `MockZkVerifier`, `MockThresholdNetwork`).
-- **`CofheClient`** — in-Solidity SDK shim. One client per "user" in your scenario; each client carries a private key and produces encrypted inputs and signed permits as if it were that user's frontend SDK.
-- **Plaintext assertions** — `expectPlaintext(handle, value)` reads the on-chain plaintext from the mock task manager. Faster than `decryptForView` and needs no permit.
+- **`CofheTest`**: abstract test base that inherits `forge-std/Test` and deploys the full CoFHE mock stack (`MockTaskManager`, `MockACL`, `MockZkVerifier`, `MockThresholdNetwork`).
+- **`CofheClient`**: in-Solidity SDK shim. One client per "user" in your scenario; each client carries a private key and produces encrypted inputs and signed ACPs as if it were that user's frontend SDK.
+- **Plaintext assertions**: `expectPlaintext(handle, value)` reads the onchain plaintext from the mock task manager. Faster than `decryptForView` and needs no ACP.
 
 ## Prerequisites
 
@@ -71,12 +71,12 @@ code_size_limit = 100000    # mocks exceed 24 KB
 ```
 
 <Warning>
-- `code_size_limit = 100000` is required — the mock contracts exceed the EIP-170 24 KB ceiling.
+- `code_size_limit = 100000` is required: the mock contracts exceed the EIP-170 24 KB ceiling.
 - `solc_version = "0.8.25"` matches the compiler used by `@fhenixprotocol/cofhe-contracts`.
 </Warning>
 
 <Note>
-`evm_version = "cancun"` is no longer required as of `@cofhe/mock-contracts@0.5.0` — `MockACL` was migrated off transient storage (`tstore`/`tload`) to block-number-based storage, and the pragma was lowered to `>=0.8.19`. Set it only if your own contracts need cancun-specific opcodes.
+`evm_version = "cancun"` is no longer required as of `@cofhe/mock-contracts@0.5.0`: `MockACL` was migrated off transient storage (`tstore`/`tload`) to block-number-based storage, and the pragma was lowered to `>=0.8.19`. Set it only if your own contracts need cancun-specific opcodes.
 </Note>
 
 </Step>
@@ -123,7 +123,7 @@ contract MyTest is CofheTest {
 
 ## Version pinning
 
-The plugin and `@cofhe/mock-contracts` pin `@fhenixprotocol/cofhe-contracts` *exactly* (no caret). Keep the three CoFHE packages aligned — otherwise `npm install` may resolve `cofhe-contracts` to a newer version that the mocks don't implement, producing `MockTaskManager should be marked as abstract` at compile time.
+The plugin and `@cofhe/mock-contracts` pin `@fhenixprotocol/cofhe-contracts` *exactly* (no caret). Keep the three CoFHE packages aligned; otherwise `npm install` may resolve `cofhe-contracts` to a newer version that the mocks don't implement, producing `MockTaskManager should be marked as abstract` at compile time.
 
 Known-aligned tuple as of writing:
 
@@ -139,15 +139,15 @@ See the [Compatibility](/get-started/introduction/compatibility) page for the ca
 
 The mocks are the same `@cofhe/mock-contracts` package the [Hardhat plugin](/client-sdk/hardhat-plugin/mock-contracts) uses. Behaviorally:
 
-- Plaintext lives on-chain in `MockTaskManager.mockStorage` (so `expectPlaintext` and `getPlaintext` work).
+- Plaintext lives onchain in `MockTaskManager.mockStorage` (so `expectPlaintext` and `getPlaintext` work).
 - No real ZK proving; encrypted inputs are signed by `MockZkVerifierSigner`.
-- Decryption is synchronous — `decryptForTx_withoutPermit` returns the result immediately.
+- Decryption is synchronous: `decryptForTx_withoutACP` returns the result immediately.
 - Mock signatures are accepted by the same `FHE.verifyDecryptResult` your contract uses on testnet.
 
 The same test code runs unchanged against real CoFHE on a deployed network.
 
 ## Next steps
 
-- [CofheTest](/client-sdk/foundry-plugin/cofhe-test) — the test base contract: `deployMocks`, `expectPlaintext`, `getPlaintext`, log toggles.
-- [CofheClient](/client-sdk/foundry-plugin/cofhe-client) — per-user shim: `createInEuintN`, `decryptForTx_withoutPermit`, `decryptForView`, permits.
-- [Testing](/client-sdk/foundry-plugin/testing) — canonical test patterns and the migration mapping from the old `@cofhe/mock-contracts/foundry/CoFheTest.sol` API.
+- [CofheTest](/client-sdk/foundry-plugin/cofhe-test): the test base contract: `deployMocks`, `expectPlaintext`, `getPlaintext`, log toggles.
+- [CofheClient](/client-sdk/foundry-plugin/cofhe-client): per-user shim: `createInEuintN`, `decryptForTx_withoutACP`, `decryptForView`, ACPs.
+- [Testing](/client-sdk/foundry-plugin/testing): canonical test patterns and the migration mapping from the old `@cofhe/mock-contracts/foundry/CoFheTest.sol` API.

--- a/client-sdk/foundry-plugin/testing.mdx
+++ b/client-sdk/foundry-plugin/testing.mdx
@@ -3,7 +3,7 @@ title: Testing
 description: "Canonical test-writing patterns for FHE contracts under Foundry"
 ---
 
-This page shows the load-bearing patterns for writing FHE contract tests under Foundry with `@cofhe/foundry-plugin`. Hardhat counterpart: [Hardhat Plugin → Testing](/client-sdk/hardhat-plugin/testing).
+This page shows the load-bearing patterns for writing FHE contract tests under Foundry with `@cofhe/foundry-plugin`. Hardhat counterpart: [Hardhat Plugin Testing](/client-sdk/hardhat-plugin/testing).
 
 ## Skeleton
 
@@ -49,16 +49,16 @@ That's the load-bearing shape. Everything below is what to add when the contract
 
 ### 2. One `CofheClient` per scenario address
 
-Each user with their own permit/encrypted inputs gets their own client. Connect with a deterministic plaintext private key — don't recycle real keys; these are visible in test output.
+Each user with their own ACP/encrypted inputs gets their own client. Connect with a deterministic plaintext private key; don't recycle real keys, these are visible in test output.
 
 ```solidity
 CofheClient bob = createCofheClient();
 bob.connect(0xB0B);         // bob.account() == vm.addr(0xB0B)
 ```
 
-You don't pass `account` to `createInEuintN` — the client is bound at `connect`.
+You don't pass `account` to `createInEuintN`: the client is bound at `connect`.
 
-### 3. `vm.prank(client.account())` to act on-chain as that user
+### 3. `vm.prank(client.account())` to act onchain as that user
 
 ```solidity
 vm.prank(bob.account());
@@ -73,9 +73,9 @@ Mismatching the prank address and the client that produced the input fails the Z
 expectPlaintext(counter.count(), uint32(2000));    // typed overload
 ```
 
-Faster than `decryptForView` and needs no permit. Reserve the SDK path for tests where the SDK behavior itself is under test.
+Faster than `decryptForView` and needs no ACP. Reserve the SDK path for tests where the SDK behavior itself is under test.
 
-### 5. Test the public-decrypt 3-step flow with `decryptForTx_withoutPermit`
+### 5. Test the public-decrypt 3-step flow with `decryptForTx_withoutACP`
 
 When the contract calls `FHE.publishDecryptResult`:
 
@@ -86,35 +86,35 @@ counter.allowCounterPublicly();   // FHE.allowPublic(handle)
 
 // Step 2: SDK fetches plaintext + threshold-network signature
 bytes32 ctHash = euint32.unwrap(counter.count());
-(, uint256 plaintext, bytes memory sig) = bob.decryptForTx_withoutPermit(ctHash);
+(, uint256 plaintext, bytes memory sig) = bob.decryptForTx_withoutACP(ctHash);
 
 // Step 3: contract verifies signature and stores plaintext
 counter.revealCounter(uint32(plaintext), sig);
 assertEq(counter.getDecryptedValue(), plaintext);
 ```
 
-Same shape runs unmodified against real CoFHE on testnet — the mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
+Same shape runs unmodified against real CoFHE on testnet: the mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
 
-### 6. Permit-based unseal: `decryptForView` for the success path
+### 6. ACP-based unseal: `decryptForView` for the success path
 
 ```solidity
-import { Permission } from "@cofhe/mock-contracts/contracts/Permissioned.sol";
+import { ACP } from "@cofhe/mock-contracts/contracts/Permissioned.sol";
 
-Permission memory bobPermit = bob.permit_createSelf();
-uint256 value = bob.decryptForView(ctHash, bobPermit);
+ACP memory bobAcp = bob.ACP_createSelf();
+uint256 value = bob.decryptForView(ctHash, bobAcp);
 assertEq(value, expected);
 ```
 
-`permit_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs — no manual `signPermissionSelf` boilerplate.
+`ACP_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs: no manual `signPermissionSelf` boilerplate.
 
 ### 7. Deny path: asserting "Alice cannot decrypt Bob's value"
 
 `decryptForView` reverts when the caller isn't on the ACL. To assert the deny path, drop down to the mock directly:
 
 ```solidity
-Permission memory alicePermit = alice.permit_createSelf();
+ACP memory aliceAcp = alice.ACP_createSelf();
 (bool allowed, string memory err, ) = mockThresholdNetwork.querySealOutput(
-    uint256(ctHash), block.chainid, alicePermit
+    uint256(ctHash), block.chainid, aliceAcp
 );
 assertFalse(allowed, "Alice should NOT be allowed");
 assertEq(err, "NotAllowed");
@@ -133,7 +133,7 @@ function testFuzz_Reset(uint32 v) public {
 }
 ```
 
-`createInEuintN` accepts the full `uintN` range — no shaping needed.
+`createInEuintN` accepts the full `uintN` range: no shaping needed.
 
 ## Migration from the old `mock-contracts` API
 
@@ -146,22 +146,22 @@ If you're upgrading from `@cofhe/mock-contracts@0.4.x` (where `CoFheTest` lived 
 | `assertHashValue(handle, value)` | `expectPlaintext(handle, value)` |
 | `mockStorage(ctHash)` | `getPlaintext(ctHash)` |
 | `createInEuint32(v, bob)` | `bob.createInEuint32(v)` |
-| `createPermissionSelf(bob)` + `signPermissionSelf(perm, bobKey)` | `bob.permit_createSelf()` (auto-signs) |
-| `createSealingKey(seed)` | `bob.createSealingKey(seed)` (rarely needed — `permit_createSelf` derives one) |
-| `queryDecrypt(hash, chainId, permit)` | `bob.decryptForView(hash, permit)` (reverts on deny) |
-| Same, asserting deny | `mockThresholdNetwork.querySealOutput(hash, block.chainid, permit)` |
+| `createPermissionSelf(bob)` + `signPermissionSelf(perm, bobKey)` | `bob.ACP_createSelf()` (auto-signs) |
+| `createSealingKey(seed)` | `bob.createSealingKey(seed)` (rarely needed: `ACP_createSelf` derives one) |
+| `queryDecrypt(hash, chainId, permit)` | `bob.decryptForView(hash, acp)` (reverts on deny) |
+| Same, asserting deny | `mockThresholdNetwork.querySealOutput(hash, block.chainid, acp)` |
 | `querySealOutput` + `unseal` | `bob.decryptForView` (does both) |
-| `decryptForTxWithoutPermit(ct)` returns `(allowed, error, plaintext)` | `bob.decryptForTx_withoutPermit(ct)` returns `(ctHash, plaintext, signature)` |
+| `decryptForTxWithoutPermit(ct)` returns `(allowed, error, plaintext)` | `bob.decryptForTx_withoutACP(ct)` returns `(ctHash, plaintext, signature)` |
 
 ## Common pitfalls
 
 <AccordionGroup>
 <Accordion title="IDE Solidity errors but `forge test` passes" icon="triangle-exclamation">
-LSPs like Wake/Cursor often resolve from the monorepo root; the plugin's remappings are package-local. **`forge` is the truth** — if `forge build` and `forge test` succeed, the test is correct.
+LSPs like Wake/Cursor often resolve from the monorepo root; the plugin's remappings are package-local. **`forge` is the truth**: if `forge build` and `forge test` succeed, the test is correct.
 </Accordion>
 
 <Accordion title="Forgetting `FHE.allowThis` in the contract" icon="key">
-Tests pass on the first op, then a second op reverts with `ACLNotAllowed` because the contract itself isn't on the ACL. Toggle `enableLogs()` to see the missing grant — every op prints a line showing whether `allowThis`/`allow` was called.
+Tests pass on the first op, then a second op reverts with `ACLNotAllowed` because the contract itself isn't on the ACL. Toggle `enableLogs()` to see the missing grant: every op prints a line showing whether `allowThis`/`allow` was called.
 </Accordion>
 
 <Accordion title="Wrong client for the prank" icon="user">
@@ -181,13 +181,13 @@ expectPlaintext(counter.count(), uint32(1)); // ✅ re-fetch
 Re-fetch after each state change.
 </Accordion>
 
-<Accordion title="Permit issuer must derive from the connected key" icon="signature">
-The `pkey` passed to `connect` must derive the address used as `permit.issuer`. `bob.permit_createSelf()` after `bob.connect(0xB0B)` produces `issuer == vm.addr(0xB0B)`. Trying to forge a mismatch fails signature verification.
+<Accordion title="ACP issuer must derive from the connected key" icon="signature">
+The `pkey` passed to `connect` must derive the address used as `acp.issuer`. `bob.ACP_createSelf()` after `bob.connect(0xB0B)` produces `issuer == vm.addr(0xB0B)`. Trying to forge a mismatch fails signature verification.
 </Accordion>
 </AccordionGroup>
 
 ## Related
 
-- [CofheTest](/client-sdk/foundry-plugin/cofhe-test) — the test base contract API.
-- [CofheClient](/client-sdk/foundry-plugin/cofhe-client) — the per-user shim API.
-- [Hardhat → Testing](/client-sdk/hardhat-plugin/testing) — the same patterns under Hardhat.
+- [CofheTest](/client-sdk/foundry-plugin/cofhe-test): the test base contract API.
+- [CofheClient](/client-sdk/foundry-plugin/cofhe-client): the per-user shim API.
+- [Hardhat Testing](/client-sdk/hardhat-plugin/testing): the same patterns under Hardhat.

--- a/client-sdk/guides/decrypt-to-tx.mdx
+++ b/client-sdk/guides/decrypt-to-tx.mdx
@@ -1,145 +1,365 @@
 ---
 title: Decrypt to Transact
-description: "Decrypt with a verifiable Threshold Network signature for on-chain use"
+description: "Reveal encrypted values onchain with a Threshold Network signature"
 ---
 
-Use `decryptForTx` to reveal a confidential (encrypted) value on-chain: it returns the plaintext together with a Threshold Network signature, so a contract can verify the reveal when you publish it in a transaction.
+Use `decryptForTx` to reveal a confidential (encrypted) value onchain: it returns the plaintext together with a Threshold Network signature, so a contract can verify the reveal when you publish it in a transaction.
 
-Common use cases:
+The flow is as follows:
+
+1. Call `decryptForTx(ctHash)` with the encrypted handle (`ctHash` in code) you want to reveal.
+2. Receive the plaintext value and a Threshold Network signature that binds that plaintext to the handle.
+3. Submit an onchain transaction that publishes or verifies the result. See [Writing Decrypt Result to Contract](/client-sdk/guides/writing-decrypt-result).
+
+Common examples:
 
 - **Unshield a confidential token**: reveal the encrypted amount you're unshielding so the contract can finalize the public transfer.
 - **Finalize a private auction / game move**: bids or moves are submitted encrypted, and the winner is revealed later in a verifiable way.
 
 <Note>
-If you only need to show plaintext in your UI (and you do **not** need an on-chain-verifiable signature), use [`decryptForView`](/client-sdk/guides/decrypt-to-view) instead.
+If you only need to show plaintext in your UI (and you do **not** need an onchain-verifiable signature), use [`decryptForView`](/client-sdk/guides/decrypt-to-view) instead.
 </Note>
 
 ## Prerequisites
 
 1. [Create and connect a client](/client-sdk/guides/client-setup).
-2. Know the on-chain encrypted handle (`ctHash`) you want to decrypt.
-3. Determine whether the contract's ACL policy for this `ctHash` requires a [permit](/client-sdk/guides/permits).
+2. Know the onchain encrypted handle (`ctHash`) you want to decrypt.
+3. Determine whether the contract-level ACL policy for this handle requires an [ACP](/client-sdk/guides/permits).
+   - If the policy allows anyone to decrypt, an ACP is not required and `.withoutACP()` will work.
+   - If the policy restricts decryption, you must use `.withACP(...)` or the decryption will fail.
+
+In most apps, you get the handle by reading it from your contract (for example a stored encrypted value, an event arg, or a return value from a view call).
+
+<Tip>
+- Onchain, a handle is represented as a `bytes32`.
+- In JavaScript/TypeScript, libraries like Viem typically give you a hex string (`0x${string}`).
+- The SDK accepts either a hex string or a `bigint`.
+</Tip>
 
 <Note>
-`decryptForTx` does not take a `utype`. It always returns the plaintext as a `bigint` because the result is intended to be passed into a transaction. If you need UI-friendly decoding, use [`decryptForView`](/client-sdk/guides/decrypt-to-view).
+`decryptForTx` does not take a `utype`. It always returns the plaintext as a `bigint` because the result is intended to be passed into a transaction (your contract decides whether that `bigint` is interpreted as `uint32`, `uint64`, and so on). If you need UI-friendly decoding (for example `boolean` or address formatting), use [`decryptForView`](/client-sdk/guides/decrypt-to-view).
 </Note>
 
-## Permit: when is it needed?
+## Reading from a contract (getting a handle)
 
-Often, `decryptForTx` is used to reveal a value that the protocol already considers OK to make public. In those cases, the contract's ACL policy can allow anyone to decrypt, and you can use `.withoutPermit()`.
+Typically, the value you want to reveal comes from a `view` call (or from an event arg / stored encrypted value).
 
-Examples where a permit is **not** needed:
-- **Unshielding**: the amount being unshielded is no longer meant to stay secret.
-- **Auction/game reveal**: it doesn't matter who submits the reveal — only that the result is verified.
+If your contract ABI uses encrypted `internalType`s (for example `internalType: "euint32"` while the ABI `type` is `bytes32`), you can convert the raw return value into a `{ ctHash, utype }` pair using `@cofhe/abi`. Here `ctHash` is the handle.
 
-If the ACL policy restricts decryption, you must use `.withPermit(...)`.
+For `decryptForTx`, you only need the handle.
 
-## What `decryptForTx` returns
-
-`.execute()` resolves to an object with:
-
-- `ctHash: bigint | string` — the ciphertext handle you decrypted
-- `decryptedValue: bigint` — the plaintext value (always a `bigint`)
-- `signature: 0x${string}` — the Threshold Network signature as a hex string
-
-## Decrypt (choose permit mode)
+Below are two equivalent ways to read an encrypted return value from a predeployed Sepolia contract and derive a handle.
 
 <CodeGroup>
 
-```typescript No permit
+```typescript Viem
+import { transformEncryptedReturnTypes } from '@cofhe/abi';
+import { createPublicClient, http } from 'viem';
+import { sepolia } from 'viem/chains';
+
+const rpcUrl =
+  process.env.SEPOLIA_RPC_URL ??
+  process.env.RPC_URL ??
+  'https://rpc.sepolia.org';
+
+// Predeployed test contract on Sepolia.
+const contractAddress =
+  '0x9e599dA5c7BA756641bA59DbecCc394CEdFC19f0' as const;
+
+const publicClient = createPublicClient({
+  chain: sepolia,
+  transport: http(rpcUrl),
+});
+
+const abi = [
+  {
+    type: 'function',
+    name: 'getValue',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32', internalType: 'euint32' }],
+  },
+] as const;
+
+const raw = await publicClient.readContract({
+  address: contractAddress,
+  abi,
+  functionName: 'getValue',
+  args: [],
+});
+
+const encrypted = transformEncryptedReturnTypes(abi, 'getValue', raw);
+
+encrypted.ctHash;
+encrypted.utype;
+```
+
+```typescript Ethers
+import { transformEncryptedReturnTypes } from '@cofhe/abi';
+import { Contract, JsonRpcProvider } from 'ethers';
+
+const contractAddress =
+  '0x9e599dA5c7BA756641bA59DbecCc394CEdFC19f0' as const;
+const rpcUrl =
+  process.env.SEPOLIA_RPC_URL ??
+  process.env.RPC_URL ??
+  'https://rpc.sepolia.org';
+
+const provider = new JsonRpcProvider(rpcUrl);
+
+const abi = [
+  {
+    type: 'function',
+    name: 'getValue',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32', internalType: 'euint32' }],
+  },
+] as const;
+
+const contract = new Contract(contractAddress, abi, provider);
+
+const raw = await contract.getValue();
+
+const encrypted = transformEncryptedReturnTypes(abi, 'getValue', raw);
+
+encrypted.ctHash;
+encrypted.utype;
+```
+
+</CodeGroup>
+
+## Preparations: ACP (only if required)
+
+Often, `decryptForTx` is used to reveal a value at a point where your protocol already considers it OK for that value to become public onchain. In those cases, there is usually no need to restrict who is allowed to perform the reveal, so the contract's ACL policy can allow anyone to decrypt.
+
+For example:
+
+- **Unshielding**: once a user chooses to unshield (convert a portion of their confidential balance into a public amount), the amount being unshielded is no longer meant to stay secret.
+- **Auction / game reveal**: when it is time to reveal the outcome, it typically does not matter who submits the reveal transaction, only that the result is revealed verifiably.
+
+In these cases, you can skip ACPs and use `.withoutACP()`.
+
+If the ACL policy restricts decryption for this handle, obtain an ACP before calling `decryptForTx`:
+
+- If decryption is restricted to your address, generate a self ACP.
+- If decryption is restricted to a different address, import an ACP from the address that is allowed to decrypt.
+
+For details, see [ACPs](/client-sdk/guides/permits).
+
+Decision guide:
+
+```text
+ACL policy for this ctHash
+|
+|- Anyone can decrypt (no restriction)
+|  `- No ACP needed
+|     `- decryptForTx(ctHash)
+|           .withoutACP()
+|           .execute()
+|
+`- Restricted to a specific address
+   |
+   |- Your address is allowed
+   |  `- Generate a self ACP
+   |     `- decryptForTx(ctHash)
+   |           .withACP()
+   |           .execute()
+   |
+   `- A different address is allowed
+      `- Import an ACP from them
+         `- decryptForTx(ctHash)
+               .withACP(importedACP)
+               .execute()
+```
+
+## Decrypt for a transaction
+
+### What `decryptForTx` returns
+
+`decryptForTx(...).execute()` resolves to an object with:
+
+- `ctHash: bigint | string`: the handle you decrypted (either a `bigint` or a `0x...` hex string)
+- `decryptedValue: bigint`: the plaintext value (always a `bigint`, even if the underlying type is for example `uint32`)
+- `signature: 0x${string}`: the Threshold Network signature as a hex string with `0x`
+
+You typically pass `decryptedValue` and `signature` directly into your transaction.
+
+### Decrypt (choose ACP mode)
+
+Choose the mode that matches the contract's ACL policy for this handle:
+
+<CodeGroup>
+
+```typescript No ACP
 const decryptResult = await client
   .decryptForTx(ctHash)
-  .withoutPermit()
+  .withoutACP()
   .execute();
 
 decryptResult.decryptedValue;
 decryptResult.signature;
 ```
 
-```typescript Active permit
+```typescript ACP (active)
 const decryptResult = await client
   .decryptForTx(ctHash)
-  .withPermit()
+  .withACP()
   .execute();
 ```
 
-```typescript Explicit permit
-const permit = await client.permits.getOrCreateSelfPermit();
+```typescript ACP (explicit)
+const acp = await client.acp.getOrCreateSelfACP();
 
 const decryptResult = await client
   .decryptForTx(ctHash)
-  .withPermit(permit)
+  .withACP(acp)
   .execute();
 ```
 
 </CodeGroup>
 
-After decrypting, see [Writing Decrypt Result to Contract](/client-sdk/guides/writing-decrypt-result) for how to publish or verify the result on-chain.
+## Next step: write the transaction
+
+Once you have `{ ctHash, decryptedValue, signature }`, you typically submit a transaction that either:
+
+- publishes the result via `FHE.publishDecryptResult(...)`, or
+- verifies it inside your contract via `FHE.verifyDecryptResult(...)`.
+
+See [Writing Decrypt Result to Contract](/client-sdk/guides/writing-decrypt-result) for examples.
 
 ## Builder API
 
-### `.execute()` — required, call last
+`decryptForTx(ctHash)` returns a builder. Before calling `.execute()`, you must select exactly one ACP mode: `.withACP(...)` or `.withoutACP()`.
+
+### `.execute()` (required, call last)
 
 Runs the decryption and returns `{ ctHash, decryptedValue, signature }`.
 
-### `.withPermit(...)` — required unless using `.withoutPermit()`
+```typescript
+const result = await client.decryptForTx(ctHash).withACP().execute();
 
-- `.withPermit()` — uses the active permit
-- `.withPermit(permitHash)` — fetches a stored permit by hash
-- `.withPermit(permit)` — uses the provided permit object
+result.decryptedValue;
+result.signature;
+```
 
-### `.withoutPermit()` — required unless using `.withPermit(...)`
+### `.onPoll(callback)` (optional)
 
-Decrypt via global allowance (no permit). Only works if the contract's ACL policy allows anyone to decrypt that `ctHash`.
+Registers a callback that runs once per poll attempt while waiting for the threshold network to complete the request.
 
-### `.setAccount(address)` — optional
-
-Overrides the account used to resolve the active/stored permit.
-
-### `.setChainId(chainId)` — optional
-
-Overrides the chain used to resolve the Threshold Network URL and permits.
-
-### `.onPoll(callback)` — optional
-
-Register a callback that fires once per poll attempt while `decryptForTx` waits for the Threshold Network to return the plaintext. Useful for surfacing progress in a UI.
+During submit retries, `requestId` is an empty string because the backend has not created a request yet. This can happen while the SDK is retrying transient `204` or short-lived `404` submit responses.
 
 ```typescript
-const decryptResult = await client
+const result = await client
   .decryptForTx(ctHash)
-  .withoutPermit()
-  .onPoll(({ operation, requestId, attemptIndex, elapsedMs, intervalMs, timeoutMs }) => {
-    console.log(`[${operation}] attempt ${attemptIndex} after ${elapsedMs}ms (next in ${intervalMs}ms, budget ${timeoutMs}ms)`);
+  .onPoll(({ attemptIndex, elapsedMs }) => {
+    console.log('decrypt polling', { attemptIndex, elapsedMs });
   })
+  .withACP()
   .execute();
+
+result.signature;
 ```
 
-The callback receives:
+### `.set404RetryTimeout(timeoutMs)` (optional)
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `operation` | `'decrypt' \| 'sealoutput'` | Which Threshold Network flow is polling. For `decryptForTx` this is always `'decrypt'`. |
-| `requestId` | `string` | The Threshold Network request id. **May be the empty string** during submit-time retries — see `.set404RetryTimeout(...)` below. |
-| `attemptIndex` | `number` | Zero-based poll attempt counter. |
-| `elapsedMs` | `number` | Time since the first submit attempt. |
-| `intervalMs` | `number` | Delay until the next poll. |
-| `timeoutMs` | `number` | Overall budget shared by submit-retries and status-polling. |
+Controls how long the SDK should keep retrying submit-time `404 Not Found` responses before failing. The default is `10000` ms. This retry only applies while the backend reports the ciphertext isn't indexed yet (`ct_not_found`); a `404` with any other error code fails immediately.
 
-### `.set404RetryTimeout(timeoutMs)` — optional
-
-Configures how long `decryptForTx` keeps retrying when the Threshold Network's submit endpoint responds with `404 Not Found` before a `requestId` is available. This typically happens on slower backends where the ciphertext isn't visible yet at submit time. Defaults to `10_000` ms.
+Use this when your backend is eventually consistent and may need a few seconds to index a freshly created ciphertext handle.
 
 ```typescript
-const decryptResult = await client
+const result = await client
   .decryptForTx(ctHash)
-  .withoutPermit()
-  .set404RetryTimeout(20_000) // give a slower backend more time
+  .set404RetryTimeout(15_000)
+  .withACP()
   .execute();
+
+result.signature;
 ```
 
-Pass `0` to disable submit-time retries (`404` becomes a hard failure). Submit retries share the same overall timeout budget as status polling, so a larger value here trades poll time for submit-recovery time.
+### `.withACP(...)` (required unless using `.withoutACP()`)
+
+Decrypt using an ACP:
+
+- `.withACP()` uses the active ACP for the resolved `chainId + account`.
+- `.withACP(acpHash)` fetches a stored ACP by hash.
+- `.withACP(acp)` uses the provided ACP object.
+
+<CodeGroup>
+
+```typescript Active ACP
+const result = await client
+  .decryptForTx(ctHash)
+  .withACP()
+  .execute();
+
+result.signature;
+```
+
+```typescript ACP object
+const acp = await client.acp.getOrCreateSelfACP();
+
+const result = await client
+  .decryptForTx(ctHash)
+  .withACP(acp)
+  .execute();
+
+result.decryptedValue;
+```
+
+```typescript ACP hash
+const result = await client
+  .decryptForTx(ctHash)
+  .withACP(acpHash)
+  .execute();
+
+result;
+```
+
+</CodeGroup>
+
+### `.withoutACP()` (required unless using `.withACP(...)`)
+
+Decrypt via global allowance (no ACP). This only works if your contract's ACL policy allows anyone to decrypt that handle.
+
+```typescript
+const result = await client
+  .decryptForTx(ctHash)
+  .withoutACP()
+  .execute();
+
+result.decryptedValue;
+```
+
+### `.setAccount(address)` (optional)
+
+Overrides the account used to resolve the active ACP / stored ACP.
+
+```typescript
+const result = await client
+  .decryptForTx(ctHash)
+  .setAccount('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+  .withACP()
+  .execute();
+
+const handleFromResult = result.ctHash;
+```
+
+### `.setChainId(chainId)` (optional)
+
+Overrides the chain used to resolve the Threshold Network URL and ACPs.
+
+```typescript
+const result = await client
+  .decryptForTx(ctHash)
+  .setChainId(11155111)
+  .withACP()
+  .execute();
+
+result.signature;
+```
 
 ## Common pitfalls
 
-- **Permit mode must be selected**: you must call exactly one of `.withPermit(...)` or `.withoutPermit()` before `.execute()`.
-- **Wrong chain/account**: permits are scoped to `chainId + account`. If you get an ACL/permit error, double-check the connected chain and account.
+- **ACP mode must be selected**: you must call exactly one of `.withACP(...)` or `.withoutACP()` before `.execute()`.
+- **Wrong chain/account**: ACPs are scoped to `chainId + account`. If you use `.withACP()` and get an ACL/ACP error, double-check you're connected to the expected chain and account (or explicitly set them via `.setChainId(...)` / `.setAccount(...)`).

--- a/client-sdk/guides/decrypt-to-view.mdx
+++ b/client-sdk/guides/decrypt-to-view.mdx
@@ -1,80 +1,192 @@
 ---
 title: Decrypt to View
-description: "Reveal encrypted values locally for UI display using permits"
+description: "Reveal encrypted values offchain for UI display using ACPs"
 ---
 
 Use `decryptForView` to reveal a confidential (encrypted) value locally in your app so you can display it in the UI.
 
-Unlike [`decryptForTx`](/client-sdk/guides/decrypt-to-tx), this flow does **not** return an on-chain-verifiable signature, and it is **not** meant to be published on-chain.
+Unlike [`decryptForTx`](/client-sdk/guides/decrypt-to-tx), this flow does **not** return an onchain-verifiable signature, and it is **not** meant to be published onchain.
 
-## Flow
+The flow is as follows:
 
-1. Read the encrypted handle (`ctHash`) from your contract.
-2. Ensure you have a permit that authorizes decryption of that value.
-3. Call `decryptForView(ctHash, utype).execute()` to get the plaintext.
+1. Read the handle (`ctHash` in code) from your contract.
+2. Ensure you have an [ACP](/client-sdk/guides/permits) that authorizes decryption of that value.
+3. Call `decryptForView(ctHash, utype)` and then run `.execute()` to get the plaintext.
 
 <Note>
-`decryptForView` always decrypts using a permit (there is no `.withoutPermit()` mode). If your protocol intends for the plaintext to become publicly visible on-chain, use [`decryptForTx`](/client-sdk/guides/decrypt-to-tx) instead.
+`decryptForView` always decrypts using an ACP (there is no `.withoutACP()` mode).
+If your protocol intends for the plaintext to become publicly visible onchain, use [`decryptForTx`](/client-sdk/guides/decrypt-to-tx) instead.
 </Note>
 
 ## Prerequisites
 
 1. [Create and connect a client](/client-sdk/guides/client-setup).
-2. Know the encrypted handle (`ctHash`) and the encrypted type (`utype`).
-3. Have a [permit](/client-sdk/guides/permits) available for the connected `chainId + account`.
+2. Know the handle (`ctHash` in code) and the encrypted type (`utype`).
+3. Have an [ACP](/client-sdk/guides/permits) available for the connected `chainId + account`.
+
+If you don't have one yet, the quickest way is to create a self ACP once per account + chain.
 
 <Tip>
-**Getting `ctHash`**: In most apps, `ctHash` comes from reading a stored encrypted value, an event arg, or a return value from a `view` call.
+**Getting a handle**
+
+In most apps, the handle comes from reading a stored encrypted value, an event arg, or a return value from a `view` call.
 </Tip>
 
 <Tip>
-**Providing `utype`**: `utype` must match the ciphertext's underlying FHE type. The SDK uses it to convert the decrypted `bigint` into a convenient JS type.
+**Providing `utype` (required; not arbitrary)**
 
-Supported `utype`s:
-- `FheTypes.Bool` → returns a `boolean`
-- `FheTypes.Uint160` (address) → returns a checksummed `0x...` string
-- `FheTypes.Uint8 | Uint16 | Uint32 | Uint64 | Uint128` → returns a `bigint`
+`utype` must match the handle's underlying FHE type. The SDK uses it to convert the decrypted `bigint` into a convenient JS type so you can display it.
+
+In many apps you can **derive `{ ctHash, utype }` from the contract ABI** using `@cofhe/abi` (see the snippets below). Here `ctHash` is the handle. If you only have a raw handle (for example from storage or event logs), you must still know which encrypted type it corresponds to.
+
+Supported `utype`s for `decryptForView`:
+
+- `FheTypes.Bool`: returns a `boolean`
+- `FheTypes.Uint160` (address): returns a checksummed `0x...` string
+- `FheTypes.Uint8 | Uint16 | Uint32 | Uint64 | Uint128`: returns a `bigint`
 </Tip>
 
-## Permit setup
+<Note>
+This is why `decryptForView` requires `utype`, but `decryptForTx` does not: tx decryption is meant for onchain publishing and returns a raw `bigint` plaintext + signature.
+</Note>
 
-If you don't have a permit yet, create one once after connecting:
+## Reading from a contract (getting a handle + `utype`)
+
+Typically, the value you want to decrypt comes from a `view` call.
+
+First, read the raw encrypted return value and convert it into `{ ctHash, utype }` using `@cofhe/abi`. Here `ctHash` is the handle.
+
+Below are two equivalent ways to read an encrypted return value from a predeployed Sepolia contract and derive a handle + `utype`.
+
+<CodeGroup>
+
+```typescript Viem
+import { transformEncryptedReturnTypes } from '@cofhe/abi';
+import { createPublicClient, http } from 'viem';
+import { sepolia } from 'viem/chains';
+
+const rpcUrl =
+  process.env.SEPOLIA_RPC_URL ??
+  process.env.RPC_URL ??
+  'https://rpc.sepolia.org';
+
+const contractAddress =
+  '0x9e599dA5c7BA756641bA59DbecCc394CEdFC19f0' as const;
+
+const publicClient = createPublicClient({
+  chain: sepolia,
+  transport: http(rpcUrl),
+});
+
+const abi = [
+  {
+    type: 'function',
+    name: 'getValue',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32', internalType: 'euint32' }],
+  },
+] as const;
+
+const raw = await publicClient.readContract({
+  address: contractAddress,
+  abi,
+  functionName: 'getValue',
+  args: [],
+});
+
+const encrypted = transformEncryptedReturnTypes(abi, 'getValue', raw);
+
+encrypted.ctHash;
+encrypted.utype;
+```
+
+```typescript Ethers
+import { transformEncryptedReturnTypes } from '@cofhe/abi';
+import { Contract, JsonRpcProvider } from 'ethers';
+
+const contractAddress =
+  '0x9e599dA5c7BA756641bA59DbecCc394CEdFC19f0' as const;
+const rpcUrl =
+  process.env.SEPOLIA_RPC_URL ??
+  process.env.RPC_URL ??
+  'https://rpc.sepolia.org';
+
+const provider = new JsonRpcProvider(rpcUrl);
+
+const abi = [
+  {
+    type: 'function',
+    name: 'getValue',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ name: '', type: 'bytes32', internalType: 'euint32' }],
+  },
+] as const;
+
+const contract = new Contract(contractAddress, abi, provider);
+
+const raw = await contract.getValue();
+
+const encrypted = transformEncryptedReturnTypes(abi, 'getValue', raw);
+
+encrypted.ctHash;
+encrypted.utype;
+```
+
+</CodeGroup>
+
+<Note>
+Depending on your contract ABI, the handle may be surfaced as either:
+
+- `bytes32`: returned as a `0x...` hex string (both viem and ethers)
+- `uint256`: returned as a `bigint` (viem and ethers v6; ethers v5 returns a `BigNumber`)
+
+`decryptForView` accepts both `bigint` and `0x...` strings (it coerces via `BigInt(...)`).
+If you're on ethers v5 and you get a `BigNumber`, convert it first (for example `BigInt(bn.toString())`).
+</Note>
+
+## ACP quickstart
+
+If you want a "just make it work" setup for UI decryption, do this once after connecting:
 
 ```typescript
 await client.connect(publicClient, walletClient);
 
-// Creates a permit if needed, stores it, and selects it as the active permit.
-await client.permits.getOrCreateSelfPermit();
+// Creates an ACP if needed, stores it, and selects it as the active ACP.
+await client.acp.getOrCreateSelfACP();
 ```
+
+After this, `decryptForView(...)` can automatically use the active ACP when you run `.execute()`.
 
 ## Decrypt for UI
 
-Choose the pattern that matches how your app manages permits:
+Choose the pattern that matches how your app manages ACPs:
 
 <CodeGroup>
 
-```typescript Active permit
+```typescript Active ACP
 await client.connect(publicClient, walletClient);
-await client.permits.getOrCreateSelfPermit();
+await client.acp.getOrCreateSelfACP();
 
 const plaintext = await client
   .decryptForView(ctHash, FheTypes.Uint32)
   .execute();
 ```
 
-```typescript Permit object
-const permit = await client.permits.getOrCreateSelfPermit();
+```typescript ACP object
+const acp = await client.acp.getOrCreateSelfACP();
 
 const plaintext = await client
   .decryptForView(ctHash, FheTypes.Uint64)
-  .withPermit(permit)
+  .withACP(acp)
   .execute();
 ```
 
-```typescript Permit hash
+```typescript ACP hash
 const plaintext = await client
   .decryptForView(ctHash, FheTypes.Uint8)
-  .withPermit(permitHash)
+  .withACP(acpHash)
   .execute();
 ```
 
@@ -82,74 +194,20 @@ const plaintext = await client
 
 ## What `decryptForView` returns
 
-Running `.execute()` resolves to a scalar JS value:
+Running `.execute()` on `decryptForView(...)` resolves to a scalar JS value (typed in TypeScript as `UnsealedItem<U>`):
 
-- Integer utypes (`Uint8`, `Uint16`, `Uint32`, `Uint64`, `Uint128`): a `bigint`
-- `FheTypes.Bool`: a `boolean`
-- `FheTypes.Uint160` (address): a checksummed `0x...` address string
+- For integer utypes (`FheTypes.Uint8 | FheTypes.Uint16 | FheTypes.Uint32 | FheTypes.Uint64 | FheTypes.Uint128`): a `bigint`
+- For `FheTypes.Bool`: a `boolean`
+- For `FheTypes.Uint160` (address): a checksummed `0x...` address string
 
-## Builder API
+If you decrypt an integer type, you'll usually want to:
 
-### `.execute()` — required, call last
+- keep it as a `bigint` and format it for display, or
+- convert to a JS `number` only if you're sure it's within safe range.
 
-Runs the decryption and returns a UI-friendly scalar value.
+## After decrypting: common UI patterns
 
-### `.withPermit(...)` — optional
-
-Select which permit to use:
-
-- `.withPermit()` — uses the active permit
-- `.withPermit(permitHash)` — fetches a stored permit by hash
-- `.withPermit(permit)` — uses the provided permit object
-
-If you don't call `.withPermit(...)`, the active permit is used by default.
-
-### `.setAccount(address)` — optional
-
-Overrides the account used to resolve the active/stored permit.
-
-### `.setChainId(chainId)` — optional
-
-Overrides the chain used to resolve the Threshold Network URL and permits.
-
-### `.onPoll(callback)` — optional
-
-Register a callback that fires once per poll attempt while `decryptForView` waits for the Threshold Network to return the sealed plaintext. Useful for surfacing decrypt progress in a UI.
-
-```typescript
-const plaintext = await client
-  .decryptForView(ctHash, FheTypes.Uint64)
-  .onPoll(({ operation, requestId, attemptIndex, elapsedMs, intervalMs, timeoutMs }) => {
-    console.log(`[${operation}] attempt ${attemptIndex} after ${elapsedMs}ms (next in ${intervalMs}ms, budget ${timeoutMs}ms)`);
-  })
-  .execute();
-```
-
-The callback receives:
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `operation` | `'decrypt' \| 'sealoutput'` | Which Threshold Network flow is polling. For `decryptForView` this is `'sealoutput'`. |
-| `requestId` | `string` | The Threshold Network request id. **May be the empty string** during submit-time retries — see `.set404RetryTimeout(...)` below. |
-| `attemptIndex` | `number` | Zero-based poll attempt counter. |
-| `elapsedMs` | `number` | Time since the first submit attempt. |
-| `intervalMs` | `number` | Delay until the next poll. |
-| `timeoutMs` | `number` | Overall budget shared by submit-retries and status-polling. |
-
-### `.set404RetryTimeout(timeoutMs)` — optional
-
-Configures how long `decryptForView` keeps retrying when the Threshold Network's submit endpoint responds with `404 Not Found` before a `requestId` is available. This typically happens on slower backends where the ciphertext isn't visible yet at submit time. Defaults to `10_000` ms.
-
-```typescript
-const plaintext = await client
-  .decryptForView(ctHash, FheTypes.Uint32)
-  .set404RetryTimeout(20_000) // give a slower backend more time
-  .execute();
-```
-
-Pass `0` to disable submit-time retries (`404` becomes a hard failure). Submit retries share the same overall timeout budget as status polling.
-
-## Common UI patterns
+Pick the pattern that matches what you're displaying:
 
 <CodeGroup>
 
@@ -160,20 +218,125 @@ const decimals = 6;
 const display = formatUnits(amount, decimals);
 ```
 
-```typescript Bigint → number (range-check)
+```typescript Bigint to number (range-check)
 const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
 const asNumber = amount <= MAX_SAFE ? Number(amount) : undefined;
 ```
 
-```typescript Booleans & addresses
+```typescript Booleans and addresses
 const statusLabel = decryptedIsAllowed ? 'Allowed' : 'Not allowed';
 const shortOwner = `${decryptedOwner.slice(0, 6)}…${decryptedOwner.slice(-4)}`;
 ```
 
 </CodeGroup>
 
+## Builder API
+
+`decryptForView(ctHash, utype)` returns a builder. Unlike `decryptForTx`, this flow always requires an ACP (there is no `.withoutACP()` mode).
+
+### `.execute()` (required, call last)
+
+Runs the decryption and returns a UI-friendly scalar value (see [What `decryptForView` returns](#what-decryptforview-returns)).
+
+```typescript
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint32)
+  .execute();
+```
+
+### `.onPoll(callback)` (optional)
+
+Registers a callback that runs once per poll attempt while waiting for the threshold network to complete the request.
+
+This is useful for showing "decrypting…" UI, measuring latency, or logging.
+
+During submit retries, `requestId` is an empty string because the backend has not created a request yet. This can happen while the SDK is retrying transient `204` or short-lived `404` submit responses.
+
+```typescript
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint32)
+  .onPoll(({ attemptIndex, elapsedMs }) => {
+    console.log('sealoutput polling', { attemptIndex, elapsedMs });
+  })
+  .execute();
+```
+
+### `.set404RetryTimeout(timeoutMs)` (optional)
+
+Controls how long the SDK should keep retrying submit-time `404 Not Found` responses before failing. The default is `10000` ms. This retry only applies while the backend reports the ciphertext isn't indexed yet (`ct_not_found`); a `404` with any other error code fails immediately.
+
+Use this when your backend is eventually consistent and may need a few seconds to index a freshly created ciphertext handle.
+
+```typescript
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint32)
+  .set404RetryTimeout(15_000)
+  .execute();
+```
+
+### `.withACP(...)` (optional)
+
+Select which ACP to use:
+
+- `.withACP()` uses the active ACP for the resolved `chainId + account`.
+- `.withACP(acpHash)` fetches a stored ACP by hash.
+- `.withACP(acp)` uses the provided ACP object.
+
+If you don't call `.withACP(...)`, `decryptForView` also uses the active ACP for the resolved `chainId + account`.
+
+<CodeGroup>
+
+```typescript Active ACP
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint8)
+  .withACP()
+  .execute();
+```
+
+```typescript ACP object
+const acp = await client.acp.getOrCreateSelfACP();
+
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint64)
+  .withACP(acp)
+  .execute();
+```
+
+```typescript ACP hash
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Bool)
+  .withACP(acpHash)
+  .execute();
+```
+
+</CodeGroup>
+
+### `.setAccount(address)` (optional)
+
+Overrides the account used to resolve the active ACP / stored ACP.
+
+```typescript
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint32)
+  .setAccount('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045')
+  .withACP()
+  .execute();
+```
+
+### `.setChainId(chainId)` (optional)
+
+Overrides the chain used to resolve the Threshold Network URL and ACPs.
+
+```typescript
+const plaintext = await client
+  .decryptForView(ctHash, FheTypes.Uint16)
+  .setChainId(11155111)
+  .withACP()
+  .execute();
+```
+
 ## Common pitfalls
 
-- **Missing permit**: `decryptForView` will fail if there is no active permit for the current `chainId + account`.
-- **Wrong `utype`**: you must pass the correct FHE type for the ciphertext.
-- **Wrong chain/account**: permits are scoped to `chainId + account`. If the user switches wallets or networks, create/select the correct permit.
+- **Missing ACP**: `decryptForView` will fail if there is no active ACP for the current `chainId + account` (or if the ACP you pass doesn't authorize decrypting that handle).
+- **Wrong `utype`**: you must pass the correct FHE type for the handle. `Bool` and `address` are converted into `boolean` / checksummed `0x...` strings; integer types stay as `bigint`.
+- **Wrong chain/account**: ACPs are scoped to `chainId + account`. If the user switches wallets or networks, create or select the correct ACP (or set them explicitly via `.setChainId(...)` / `.setAccount(...)`).

--- a/client-sdk/guides/permits.mdx
+++ b/client-sdk/guides/permits.mdx
@@ -1,153 +1,158 @@
 ---
-title: Permits
-description: "Create and manage EIP-712 permits for decryption authorization"
+title: ACPs
+description: "EIP-712 signed ACPs (Access Control Permissions) for accessing encrypted onchain data"
 ---
 
-Permits are EIP-712 signatures that authorize decryption of confidential data. The `issuer` field identifies who is accessing the data — the issuer must have been granted access on-chain via `FHE.allow(handle, address)`. When a permit is used, CoFHE validates it against the ACL contract to confirm that the issuer has access to the requested encrypted handle.
+ACPs (Access Control Permissions, formerly called permits) are EIP-712 signatures that authorize decryption of confidential data. The `issuer` field identifies who is accessing the data. The issuer must have been granted access onchain via `FHE.allow(handle, address)`. When an ACP is used, CoFHE validates it against the ACL contract to confirm that the issuer has access to the requested encrypted handle.
 
-Each permit includes a sealing keypair. The public key is sent to CoFHE so it can re-encrypt the data for the permit holder. The private key stays client-side and is used to unseal the returned data.
+Each ACP includes a sealing keypair. The public key is sent to CoFHE so it can re-encrypt the data for the ACP holder. The private key stays client-side and is used to unseal the returned data. ACPs are stored locally and identified by a deterministic hash of their fields.
 
-## When do you need a permit?
+ACPs can be used to decrypt your own data (self ACPs), or to delegate your access to another party (sharing ACPs).
 
-- **`decryptForView`**: always requires a permit.
-- **`decryptForTx`**: depends on the contract's ACL policy for that `ctHash`.
-  - If the policy allows anyone to decrypt, you can use `.withoutPermit()`.
-  - If the policy restricts decryption, you must use `.withPermit(...)`.
+<Info>
+The examples below show two approaches for working with ACPs. The `client.acp` API is the recommended approach: it automatically signs ACPs with the connected wallet and manages the ACP store. The `ACPUtils` API is a lower-level alternative that gives you direct control over signing and storage.
+</Info>
+
+## When do you need an ACP?
+
+- **`decryptForView`**: always requires an ACP.
+- **`decryptForTx`**: depends on the contract's ACL policy for that handle (`ctHash` in code).
+  - If the policy allows anyone to decrypt, you can use `.withoutACP()`.
+  - If the policy restricts decryption, you must use `.withACP(...)`.
 
 ## Prerequisites
 
-[Create and connect a client](/client-sdk/guides/client-setup). Permits are scoped to a **chainId + account**.
+[Create and connect a client](/client-sdk/guides/client-setup). ACPs are scoped to a **chainId + account**. The SDK uses the connected chain and account by default.
 
 ## Quick start
 
-<Info>
-The examples below show two approaches. The `client.permits` API is the recommended approach — it automatically signs permits with the connected wallet and manages the permit store. The `PermitUtils` API is a lower-level alternative that gives you direct control over signing and storage.
-</Info>
+The recommended approach is to create (or reuse) a self ACP. Once created, it is stored and set as the active ACP for the connected chain and account.
 
 <CodeGroup>
 
-```typescript client.permits (recommended)
+```typescript client.acp (recommended)
 await client.connect(publicClient, walletClient);
 
-// Returns the active self permit if one exists, otherwise creates and signs a new one.
-const permit = await client.permits.getOrCreateSelfPermit();
+// Returns the active self ACP if one exists, otherwise creates and signs a new one.
+const acp = await client.acp.getOrCreateSelfACP();
 ```
 
-```typescript PermitUtils
+```typescript ACPUtils
 import {
-  PermitUtils,
-  setPermit,
-  setActivePermitHash,
-} from '@cofhe/sdk/permits';
+  ACPUtils,
+  setACP,
+  setActiveACPHash,
+} from '@cofhe/sdk/acps';
 
-const permit = await PermitUtils.createSelfAndSign(
+const acp = await ACPUtils.createSelfAndSign(
   { issuer: walletClient.account.address },
   publicClient,
   walletClient
 );
 
-// Manually store and activate the permit
+// Manually store and activate the ACP
 const chainId = await publicClient.getChainId();
 const account = walletClient.account.address;
-setPermit(chainId, account, permit);
-setActivePermitHash(chainId, account, permit.hash);
+setACP(chainId, account, acp);
+setActiveACPHash(chainId, account, acp.hash);
 ```
 
 </CodeGroup>
 
-After this, the active permit is picked up automatically:
+After this, the active ACP is picked up automatically:
 
-- `decryptForView(...).execute()` uses the active permit.
-- `decryptForTx(...).withPermit().execute()` uses the active permit.
+- `decryptForView(...).execute()` uses the active ACP.
+- `decryptForTx(...).withACP().execute()` uses the active ACP.
 
-## Permit types
+## ACP types
 
 | Type | Who signs | Use case |
 | --- | --- | --- |
 | `self` | issuer only | Decrypt your own data (most common) |
 | `sharing` | issuer only | A shareable "offer" created by the issuer for a recipient |
-| `recipient` | recipient (includes issuer signature) | The imported permit after the recipient signs it |
+| `recipient` | recipient (and includes issuer signature) | The imported ACP after the recipient signs it |
 
 <Note>
-- Permit `expiration` is a unix timestamp in **seconds**. The default is **7 days from creation**.
-- When a permit is created via `client.permits.*`, it is automatically stored and set as the active permit.
+- An ACP includes a **sealing keypair**. The public key is sent to CoFHE for re-encryption. The private key stays client-side for unsealing.
+- ACP `expiration` is a unix timestamp in **seconds**. The default is **7 days from creation**.
+- When an ACP is created via `client.acp.*`, it is automatically stored and set as the active ACP for the current chain and account.
 </Note>
 
-## Creating a self permit
+## Creating a self ACP
 
-A self permit lets you decrypt data that was allowed to your address.
+A self ACP lets you decrypt data that was allowed to your address. Use `createSelf` to always create a new ACP, or `getOrCreateSelfACP` to reuse an existing active ACP.
 
 ### createSelf
 
 <CodeGroup>
 
-```typescript client.permits
+```typescript client.acp
 await client.connect(publicClient, walletClient);
 
-const permit = await client.permits.createSelf({
+const acp = await client.acp.createSelf({
   issuer: walletClient.account.address,
-  name: 'My self permit',
+  name: 'My self ACP',
 });
 
-permit.type; // 'self'
-permit.hash; // deterministic hash
+acp.type; // 'self'
+acp.hash; // deterministic hash
 ```
 
-```typescript PermitUtils
-import { PermitUtils } from '@cofhe/sdk/permits';
+```typescript ACPUtils
+import { ACPUtils } from '@cofhe/sdk/acps';
 
-const permit = await PermitUtils.createSelfAndSign(
+const acp = await ACPUtils.createSelfAndSign(
   {
     issuer: walletClient.account.address,
-    name: 'My self permit',
+    name: 'My self ACP',
   },
   publicClient,
   walletClient
 );
 
-permit.type; // 'self'
-permit.hash; // deterministic hash
+acp.type; // 'self'
+acp.hash; // deterministic hash
 ```
 
 </CodeGroup>
 
-### getOrCreateSelfPermit
+### getOrCreateSelfACP
 
-Returns the active self permit if one exists. Otherwise creates and signs a new one. This is the recommended approach for most applications.
+Only available via the `client.acp` API. Returns the active self ACP if one exists. Otherwise creates and signs a new one. This is the recommended approach for most applications.
 
 ```typescript
 await client.connect(publicClient, walletClient);
 
-const permit = await client.permits.getOrCreateSelfPermit();
-permit.type; // 'self'
+const acp = await client.acp.getOrCreateSelfACP();
+acp.type; // 'self'
 ```
 
-## Sharing permits
+## Sharing ACPs
 
-Sharing permits let an issuer delegate their ACL access to a recipient. The recipient can then decrypt the issuer's data without needing their own `FHE.allow`.
+Sharing ACPs let an issuer delegate their ACL access to a recipient. The recipient can then decrypt the issuer's data without needing their own `FHE.allow`. This flow may be useful for auditors or other parties that need to access data but do not have the ability to grant themselves access.
 
 <Steps>
 
-<Step title="Issuer creates a sharing permit">
+<Step title="Issuer creates a sharing ACP">
 
-The issuer creates a sharing permit specifying the recipient's address.
+The issuer creates a sharing ACP specifying the recipient's address. The issuer's signature does not include a sealing key.
 
 <CodeGroup>
 
-```typescript client.permits
+```typescript client.acp
 await client.connect(publicClient, walletClient);
 
-const sharingPermit = await client.permits.createSharing({
+const sharingACP = await client.acp.createSharing({
   issuer: walletClient.account.address,
   recipient,
   name: 'Share with recipient',
 });
 ```
 
-```typescript PermitUtils
-import { PermitUtils } from '@cofhe/sdk/permits';
+```typescript ACPUtils
+import { ACPUtils } from '@cofhe/sdk/acps';
 
-const sharingPermit = await PermitUtils.createSharingAndSign(
+const sharingACP = await ACPUtils.createSharingAndSign(
   {
     issuer: walletClient.account.address,
     recipient,
@@ -162,14 +167,14 @@ const sharingPermit = await PermitUtils.createSharingAndSign(
 
 </Step>
 
-<Step title="Issuer exports the permit">
+<Step title="Issuer exports the ACP">
 
-Export the permit as a JSON blob and share it with the recipient.
+Export the ACP as a JSON blob and share it with the recipient.
 
 ```typescript
-import { PermitUtils } from '@cofhe/sdk/permits';
+import { ACPUtils } from '@cofhe/sdk/acps';
 
-const exported = PermitUtils.export(sharingPermit);
+const exported = ACPUtils.export(sharingACP);
 ```
 
 <Info>
@@ -177,34 +182,34 @@ The exported JSON does not contain any sensitive data and can be shared via any 
 </Info>
 
 <Warning>
-Do not share `serialize(permit)` output — serialization is meant for local persistence and includes the sealing private key.
+Do not share `serialize(acp)` output. Serialization is meant for local persistence and includes the sealing private key.
 </Warning>
 
 </Step>
 
 <Step title="Recipient imports and signs">
 
-The recipient imports the exported JSON and signs it with their wallet. On import, a new sealing key is generated for the recipient.
+The recipient imports the exported JSON and signs it with their wallet. On import, a new sealing key is generated for the recipient. The recipient's sealing key is the one CoFHE uses for re-encryption. The resulting ACP is stored and set as active.
 
 <CodeGroup>
 
-```typescript client.permits
+```typescript client.acp
 await client.connect(publicClient, walletClient);
 
-const recipientPermit = await client.permits.importShared(exported);
+const recipientACP = await client.acp.importShared(exported);
 
-recipientPermit.type; // 'recipient'
-recipientPermit.hash;
+recipientACP.type; // 'recipient'
+recipientACP.hash;
 ```
 
-```typescript PermitUtils
+```typescript ACPUtils
 import {
-  PermitUtils,
-  setPermit,
-  setActivePermitHash,
-} from '@cofhe/sdk/permits';
+  ACPUtils,
+  setACP,
+  setActiveACPHash,
+} from '@cofhe/sdk/acps';
 
-const recipientPermit = await PermitUtils.importSharedAndSign(
+const recipientACP = await ACPUtils.importSharedAndSign(
   exported,
   publicClient,
   walletClient
@@ -212,8 +217,8 @@ const recipientPermit = await PermitUtils.importSharedAndSign(
 
 const chainId = await publicClient.getChainId();
 const account = walletClient.account.address;
-setPermit(chainId, account, recipientPermit);
-setActivePermitHash(chainId, account, recipientPermit.hash);
+setACP(chainId, account, recipientACP);
+setActiveACPHash(chainId, account, recipientACP.hash);
 ```
 
 </CodeGroup>
@@ -222,94 +227,81 @@ setActivePermitHash(chainId, account, recipientPermit.hash);
 
 </Steps>
 
-## Active permit management
+## Sharing onchain
 
-The SDK tracks all stored permits and an **active permit hash** per `chainId + account`. Creating or importing a permit via `client.permits.*` automatically stores it and selects it as active.
+Instead of exporting JSON and sending it over a second channel, the issuer can post the share to the onchain **ACP share registry**. The recipient discovers it from any cofhesdk-enabled app and imports it directly, with no copy-paste.
 
-### List stored permits
+Configure the registry address per chain:
 
 ```typescript
-const permits = client.permits.getPermits();
-Object.keys(permits); // permit hashes
+const config = createCofheConfig({
+  // ...
+  acp: {
+    sharingRegistry: { 11155111: '0x…' },
+  },
+});
 ```
 
-### Read / select the active permit
+### Issuer shares onchain
 
 ```typescript
-const active = client.permits.getActivePermit();
+const sharingAcp = await client.acp.createSharing({
+  issuer: '0x…', // connected account
+  recipient: recipientAddress,
+});
+
+// posts the signed share payload to the registry
+const { txHash, shareId } = await client.acp.shareOnChain(sharingAcp);
+```
+
+Only signed sharing ACPs can be posted (same rule as `export()`), and only by their issuer. The issuer can retract a pending share with `client.acp.cancelShare(shareId)`.
+
+### Recipient discovers and imports
+
+```typescript
+// importable shares addressed to the connected account (unexpired, not revoked)
+const incoming = await client.acp.getIncomingShares();
+
+// fills in the recipient's sealing key, signs, stores and activates
+const acp = await client.acp.importFromChain(incoming[0]);
+
+// optionally clean up the onchain entry afterwards (or decline a share)
+await client.acp.dismissShare(incoming[0].shareId);
+```
+
+The registry lists only importable shares: expired shares and shares whose underlying ACP was revoked are filtered out. Everything posted is cleartext by design (the same data as the exported JSON). Note that posting onchain makes the issuer-to-recipient relationship public.
+
+## Active ACP management
+
+The SDK tracks all stored ACPs and an **active ACP hash** per `chainId + account`. Creating or importing an ACP via `client.acp.*` automatically stores it and selects it as active.
+
+### List stored ACPs
+
+```typescript
+const acps = client.acp.getACPs();
+Object.keys(acps); // ACP hashes
+```
+
+### Read / select the active ACP
+
+```typescript
+const active = client.acp.getActiveACP();
 active?.hash;
 
-client.permits.selectActivePermit(somePermitHash);
+client.acp.selectActiveACP(someACPHash);
 ```
 
-### Removing permits
+### Removing ACPs
 
 ```typescript
-client.permits.removePermit(permitHash);
-client.permits.removeActivePermit();
+client.acp.removeACP(acpHash);
+client.acp.removeActiveACP();
 ```
-
-## Validating permits
-
-Since `@cofhe/sdk@0.5.0`, `PermitUtils.validate` enforces the **full** check: schema + signed + not-expired. The decrypt flows (`decryptForView`, `decryptForTx` with `.withPermit(...)`) call this for you and surface failures as typed errors — you only need to validate manually when you want to inspect or filter permits before using them.
-
-### Throwing helpers — `PermitUtils.*`
-
-| Function | What it checks | Behavior on failure |
-| --- | --- | --- |
-| `PermitUtils.validate(permit)` | Schema **and** signed **and** not-expired. | Throws (`Permit is expired` / `Permit is not signed` / schema error). |
-| `PermitUtils.validateSchema(permit)` | Schema only (shape + invariants). | Throws on schema failure; does **not** check expiry or signatures. |
-
-Use `validateSchema` when you've just received a permit from the wire (e.g. an imported sharing permit) and want to reject malformed payloads without yet caring about expiry.
-
-```typescript
-import { PermitUtils } from '@cofhe/sdk/permits';
-
-try {
-  PermitUtils.validate(permit);
-  // permit is schema-valid, signed, and not expired
-} catch (err) {
-  // err.message is "Permit is expired" / "Permit is not signed" / a Zod schema error
-}
-```
-
-### Non-throwing helpers — `ValidationUtils.*`
-
-For inspection without exception handling, use the `ValidationUtils` helpers. They return a typed `ValidationResult`:
-
-```typescript
-import { ValidationUtils } from '@cofhe/sdk/permits';
-
-const result = ValidationUtils.isValid(permit);
-
-result.valid;  // boolean
-result.error;  // 'invalid-schema' | 'expired' | 'not-signed' | null
-```
-
-| Function | Returns | Use case |
-| --- | --- | --- |
-| `ValidationUtils.isValid(permit)` | `ValidationResult` | Full check (schema + signed + not-expired) without throwing. |
-| `ValidationUtils.isSignedAndNotExpired(permit)` | `ValidationResult` | Skip the schema parse if you already validated the shape. |
-| `ValidationUtils.isSigned(permit)` | `boolean` | "Does it carry a signature on the issuer / recipient side as appropriate?" |
-| `ValidationUtils.isExpired(permit)` | `boolean` | Compare `permit.expiration` to current time. |
-
-<Tip>
-Pattern-match on `result.error` to render a precise UI message:
-
-```typescript
-switch (ValidationUtils.isValid(permit).error) {
-  case 'expired':         return 'This permit has expired — please re-sign.';
-  case 'not-signed':      return 'Permit is awaiting signature.';
-  case 'invalid-schema':  return 'Imported permit is malformed.';
-  case null:              return null;
-}
-```
-</Tip>
 
 ## Persistence and security
 
-- The SDK persists permits in a store keyed by `chainId + account`.
-- In web environments, this store uses `localStorage` under the key `cofhesdk-permits`.
-- A stored permit includes the **sealing private key**. Treat it like a secret.
-  - Never share serialized permits with other users.
-  - To share access, use `PermitUtils.export(...)` which strips sensitive fields.
+- The SDK persists ACPs in a store keyed by `chainId + account`.
+- In web and React environments, this store uses `localStorage` under the key `cofhesdk-acps`.
+- A stored ACP includes the **sealing private key**. Treat it like a secret.
+  - Never share serialized ACPs with other users.
+  - To share access, use `ACPUtils.export(...)` which strips sensitive fields.

--- a/client-sdk/hardhat-plugin/testing.mdx
+++ b/client-sdk/hardhat-plugin/testing.mdx
@@ -7,7 +7,7 @@ This page shows the common patterns for writing Hardhat tests with the CoFHE plu
 
 ## Test setup
 
-Use `hre.cofhe.createClientWithBatteries` in a `before` hook. It creates and connects a fully configured `CofheClient` — including a self-permit — so the client is ready for every test in the suite:
+Use `hre.cofhe.createClientWithBatteries` in a `before` hook. It creates and connects a fully configured `CofheClient`, including a self ACP, so the client is ready for every test in the suite:
 
 ```typescript
 import hre from 'hardhat';
@@ -25,7 +25,7 @@ before(async () => {
 
 See [Client](/client-sdk/hardhat-plugin/client) for manual setup options.
 
-## Encrypt → store → decrypt
+## Encrypt, store, decrypt
 
 The core test loop: encrypt a value, pass it to a contract, then decrypt the stored handle.
 
@@ -55,7 +55,7 @@ expect(decrypted).to.equal(100n);
 
 ## Reading plaintext directly
 
-In tests you can bypass the normal decrypt flow and read the raw plaintext stored by the mock contracts. This is useful for asserting contract state without needing a permit:
+In tests you can bypass the normal decrypt flow and read the raw plaintext stored by the mock contracts. This is useful for asserting contract state without needing an ACP:
 
 ```typescript
 import hre from 'hardhat';
@@ -69,21 +69,21 @@ await hre.cofhe.mocks.expectPlaintext(ctHash, 100n);
 
 See [Mock Contracts](/client-sdk/hardhat-plugin/mock-contracts) for details.
 
-## Permits
+## ACPs
 
-`createClientWithBatteries` pre-generates a self-permit, so `decryptForView` and `decryptForTx().withPermit()` work immediately. For tests that need named permits or multiple signers, create them explicitly:
+`createClientWithBatteries` pre-generates a self ACP, so `decryptForView` and `decryptForTx().withACP()` work immediately. For tests that need named ACPs or multiple signers, create them explicitly:
 
 ```typescript
-import { PermitUtils } from '@cofhe/sdk/permits';
+import { ACPUtils } from '@cofhe/sdk/acps';
 
-const permit = await cofheClient.permits.createSelf({
+const acp = await cofheClient.acp.createSelf({
   issuer: signer.address,
-  name: 'My Test Permit',
+  name: 'My Test ACP',
 });
 
-// Select it as the active permit
-const permitHash = PermitUtils.getHash(permit);
-cofheClient.permits.selectActivePermit(permitHash);
+// Select it as the active ACP
+const acpHash = ACPUtils.getHash(acp);
+cofheClient.acp.selectActiveACP(acpHash);
 ```
 
 Alternatively, create a separate client for each signer:
@@ -98,43 +98,43 @@ const aliceClient = await hre.cofhe.createClientWithBatteries(alice);
 
 ## `decryptForTx` patterns
 
-[`decryptForTx`](/client-sdk/guides/decrypt-to-tx) returns a `{ ctHash, decryptedValue, signature }` tuple for on-chain submission. The permit mode must be selected explicitly.
+[`decryptForTx`](/client-sdk/guides/decrypt-to-tx) returns a `{ ctHash, decryptedValue, signature }` tuple for onchain submission. The ACP mode must be selected explicitly.
 
-### Globally allowed values (`.withoutPermit()`)
+### Globally allowed values (`.withoutACP()`)
 
-When a contract calls `FHE.allowPublic(handle)`, anyone can decrypt without a permit:
+When a contract calls `FHE.allowPublic(handle)`, anyone can decrypt without an ACP:
 
 ```typescript
 import { expect } from 'chai';
 
 const result = await cofheClient
   .decryptForTx(publicCtHash)
-  .withoutPermit()
+  .withoutACP()
   .execute();
 
 expect(result.decryptedValue).to.equal(55n);
 ```
 
-### Access-controlled values (`.withPermit()`)
+### Access-controlled values (`.withACP()`)
 
-For handles restricted by ACL policy, supply a permit:
+For handles restricted by ACL policy, supply an ACP:
 
 <CodeGroup>
 
-```typescript Explicit permit
+```typescript Explicit ACP
 const result = await cofheClient
   .decryptForTx(ctHash)
-  .withPermit(permit)
+  .withACP(acp)
   .execute();
 
 expect(result.decryptedValue).to.equal(99n);
 ```
 
-```typescript Active permit
-// resolves the active permit automatically
+```typescript Active ACP
+// resolves the active ACP automatically
 const result = await cofheClient
   .decryptForTx(ctHash)
-  .withPermit()
+  .withACP()
   .execute();
 
 expect(result.decryptedValue).to.equal(99n);

--- a/client-sdk/introduction/mental-model.mdx
+++ b/client-sdk/introduction/mental-model.mdx
@@ -3,11 +3,11 @@ title: Mental Model
 description: "Understand how data flows through FHE-enabled dApps using the @cofhe/sdk"
 ---
 
-To understand how `@cofhe/sdk` fits into the Fhenix framework, you'll explore a simple mental model using a Counter smart contract example. This will show you how data flows through FHE-enabled dApps—from encryption to computation to decryption.
+To understand how `@cofhe/sdk` fits into the Fhenix framework, you'll explore a simple mental model using a Counter smart contract example. This will show you how data flows through FHE-enabled dApps: from encryption to computation to decryption.
 
 ## The Counter Example
 
-Imagine a smart contract called **Counter** where each user has their own private counter. Users can increment their counter and read its value with complete privacy—no one, including the smart contract itself, can see the actual counter values.
+Imagine a smart contract called **Counter** where each user has their own private counter. Users can increment their counter and read its value with complete privacy: no one, including the smart contract itself, can see the actual counter values.
 
 ### Key Concepts
 
@@ -64,8 +64,8 @@ When a user wants to read their counter value, they use one of the SDK's two dec
 **For UI display (`decryptForView`):**
 
 1. The user reads the encrypted handle (`ctHash`) from the contract
-2. A permit authorizes decryption — created via `client.permits.getOrCreateSelfPermit()`
-3. The SDK requests re-encryption from the Threshold Network using the permit's sealing key
+2. An ACP authorizes decryption, created via `client.acp.getOrCreateSelfACP()`
+3. The SDK requests re-encryption from the Threshold Network using the ACP's sealing key
 4. The plaintext is returned locally for display
 
 **For on-chain use (`decryptForTx`):**
@@ -79,7 +79,7 @@ When a user wants to read their counter value, they use one of the SDK's two dec
 
 This is like exchanging locks on the box:
 - The box starts locked with the CoFHE co-processor's lock
-- The user sends their own lock to the co-processor (via the permit's sealing key)
+- The user sends their own lock to the co-processor (via the ACP's sealing key)
 - The co-processor removes its lock and applies the user's lock
 - The box remains locked throughout, but now only the user can open it
 - The data remains private at every step
@@ -118,7 +118,7 @@ sequenceDiagram
     Blockchain->>Contract: getCounter(userAddress)
     Contract-->>SDK: ctHash (encrypted handle)
 
-    SDK->>SDK: Use permit with sealing key
+    SDK->>SDK: Use ACP with sealing key
     SDK->>CoFHE: decryptForView(ctHash, FheTypes.Uint32)
     CoFHE->>CoFHE: Re-encrypt with user's sealing key
     CoFHE-->>SDK: Re-encrypted data
@@ -131,7 +131,7 @@ sequenceDiagram
 1. **Encryption happens client-side**: The SDK encrypts data with ZK proofs before it reaches the blockchain
 2. **Computation happens on-chain**: Smart contracts perform operations on encrypted data via `FHE.sol`
 3. **FHE enables privacy-preserving computation**: The blockchain never sees plaintext values
-4. **Permits enable access control**: EIP-712 signed permits authorize who can decrypt specific data
+4. **ACPs enable access control**: EIP-712 signed ACPs (Access Control Permissions, formerly permits) authorize who can decrypt specific data
 5. **Two decryption paths**: `decryptForView` for UI display, `decryptForTx` for on-chain verification
 
-This architecture ensures that sensitive data remains private throughout its entire lifecycle—from input to computation to output—while still enabling powerful decentralized applications.
+This architecture ensures that sensitive data remains private throughout its entire lifecycle, from input to computation to output, while still enabling powerful decentralized applications.

--- a/client-sdk/introduction/migrating-from-cofhejs.mdx
+++ b/client-sdk/introduction/migrating-from-cofhejs.mdx
@@ -3,16 +3,16 @@ title: Migrating from cofhejs
 description: "Side-by-side migration guide from cofhejs to @cofhe/sdk"
 ---
 
-`@cofhe/sdk` is the successor to `cofhejs`, redesigned around an explicit, builder-pattern API that gives you full control over encryption, decryption, and permit management.
+`@cofhe/sdk` is the successor to `cofhejs`, redesigned around an explicit, builder-pattern API that gives you full control over encryption, decryption, and ACP management.
 
-### Why migrate?
+## Why migrate?
 
-- **Explicit API** — no more implicit initialization or auto-generated permits. Every action is opt-in.
-- **Builder pattern** — `encryptInputs`, `decryptForView`, and `decryptForTx` use a chainable builder so you can set overrides (account, chain, callbacks) before calling `.execute()`.
-- **`decryptForTx` feature** — `cofhejs` does not provide an API for generating decryption signatures for on-chain usage.
-- **Deferred key loading** — FHE keys and TFHE WASM are fetched lazily on the first `encryptInputs` call, not during initialization.
-- **Better multichain support** — configure multiple chains up front and override per-call.
-- **Structured errors** — typed `CofheError` objects with error codes replace the `Result` wrapper.
+- **Explicit API**: no more implicit initialization or auto-generated permits/ACPs. Every action is opt-in.
+- **Builder pattern**: `encryptInputs`, `decryptForView`, and `decryptForTx` use a chainable builder so you can set overrides (account, chain, callbacks) before calling `.execute()`.
+- **`decryptForTx` feature**: `cofhejs` does not provide an API for generating decryption signatures for onchain usage.
+- **Deferred key loading**: FHE keys and TFHE WASM are fetched lazily on the first `encryptInputs` call, not during initialization.
+- **Better multichain support**: configure multiple chains up front and override per-call.
+- **Structured errors**: typed `CofheError` objects with error codes replace the `Result` wrapper.
 
 ### Requirements
 
@@ -30,13 +30,13 @@ npm uninstall cofhejs && npm install @cofhe/sdk
 
 ## 1. Initialization
 
-The single `cofhejs.initializeWithEthers(...)` / `cofhejs.initializeWithViem(...)` call is replaced by a three-step flow: create a config, create a client, then connect. FHE keys and WASM are no longer fetched eagerly during init — they are deferred until the first `encryptInputs` call.
+The single `cofhejs.initializeWithEthers(...)` / `cofhejs.initializeWithViem(...)` call is replaced by a three-step flow: create a config, create a client, then connect. FHE keys and WASM are no longer fetched eagerly during init; they are deferred until the first `encryptInputs` call.
 
 <Accordion title="Changes">
 
 | | `cofhejs` | `@cofhe/sdk` |
 | --- | --- | --- |
-| **Entry** | `cofhejs.initializeWithEthers(...)` / `cofhejs.initializeWithViem(...)` | `createCofheConfig(...)` → `createCofheClient(config)` → `client.connect(...)` |
+| **Entry** | `cofhejs.initializeWithEthers(...)` / `cofhejs.initializeWithViem(...)` | `createCofheConfig(...)` then `createCofheClient(config)` then `client.connect(...)` |
 | **Key fetching** | Immediate (during init) | Deferred (first `encryptInputs` call) |
 | **WASM init** | Immediate (during init) | Deferred (first `encryptInputs` call) |
 | **Environment** | `"LOCAL"` / `"TESTNET"` / `"MAINNET"` string | Chain objects via `supportedChains: [chains.sepolia]` |
@@ -171,17 +171,17 @@ The `Encryptable` factory functions (`Encryptable.uint32(...)`, `Encryptable.boo
 
 `cofhejs` has a single `unseal` function. `@cofhe/sdk` splits decryption into two purpose-built methods:
 
-- **`decryptForView`** — returns the plaintext for UI display (no on-chain signature).
-- **`decryptForTx`** — returns the plaintext **and** a Threshold Network signature for on-chain verification.
+- **`decryptForView`**: returns the plaintext for UI display (no onchain signature).
+- **`decryptForTx`**: returns the plaintext **and** a Threshold Network signature for onchain verification.
 
 <Accordion title="Changes">
 
 | | `cofhejs` | `@cofhe/sdk` |
 | --- | --- | --- |
 | **Function** | `cofhejs.unseal(sealed, type)` | `client.decryptForView(ctHash, type)` or `client.decryptForTx(ctHash)` |
-| **Permit handling** | Automatic (uses most recent permit) | Explicit — `.withPermit()` / `.withoutPermit()` |
+| **ACP handling** | Automatic (uses most recent permit) | Explicit: `.withACP()` / `.withoutACP()` |
 | **Return value** | `Result<bigint \| boolean \| string>` | Direct value for view; `{ ctHash, decryptedValue, signature }` for tx |
-| **On-chain verification** | Not built in | `decryptForTx` returns a signature for `FHE.publishDecryptResult(...)` |
+| **Onchain verification** | Not built in | `decryptForTx` returns a signature for `FHE.publishDecryptResult(...)` |
 
 </Accordion>
 
@@ -201,7 +201,7 @@ if (!result.success) {
 console.log(result.data); // bigint
 ```
 
-### After (@cofhe/sdk) — viewing in UI
+### After (@cofhe/sdk): viewing in UI
 
 ```typescript
 import { FheTypes } from '@cofhe/sdk';
@@ -213,7 +213,7 @@ const balance = await client
   .execute();
 ```
 
-### After (@cofhe/sdk) — publishing on-chain
+### After (@cofhe/sdk): publishing onchain
 
 <CodeGroup>
 
@@ -222,7 +222,7 @@ const ctHash = await myContract.getEncryptedAmount();
 
 const { decryptedValue, signature } = await client
   .decryptForTx(ctHash)
-  .withoutPermit()
+  .withoutACP()
   .execute();
 
 await myContract.publishDecryptResult(ctHash, decryptedValue, signature);
@@ -246,18 +246,18 @@ contract MyContract {
 
 </CodeGroup>
 
-## 4. Permits
+## 4. ACPs (formerly permits)
 
-Permits are no longer auto-generated during initialization. All permit operations are now explicit through `client.permits`.
+ACPs are no longer auto-generated during initialization. All ACP operations are now explicit through `client.acp`. In `cofhejs` these were called permits.
 
 <Accordion title="Changes">
 
 | | `cofhejs` | `@cofhe/sdk` |
 | --- | --- | --- |
-| **Auto-generation** | `generatePermit: true` (default) | Never — always explicit |
-| **Creation** | `cofhejs.createPermit({ type, issuer })` | `client.permits.createSelf(...)`, `client.permits.createSharing(...)` |
-| **Return type** | `Result<Permit>` | Direct `Permit` object |
-| **Active permit** | Implicitly used by `unseal` | `getOrCreateSelfPermit()` sets active; used automatically by decrypt methods |
+| **Auto-generation** | `generatePermit: true` (default) | Never: always explicit |
+| **Creation** | `cofhejs.createPermit({ type, issuer })` | `client.acp.createSelf(...)`, `client.acp.createSharing(...)` |
+| **Return type** | `Result<Permit>` | Direct `ACP` object |
+| **Active ACP** | Implicitly used by `unseal` | `getOrCreateSelfACP()` sets active; used automatically by decrypt methods |
 
 </Accordion>
 
@@ -280,16 +280,16 @@ const result = await cofhejs.createPermit({
 ### After (@cofhe/sdk)
 
 ```typescript
-// Create a self permit (prompts for wallet signature)
-const permit = await client.permits.createSelf({
+// Create a self ACP (prompts for wallet signature)
+const acp = await client.acp.createSelf({
   issuer: account,
-  name: 'My dApp permit',
+  name: 'My dApp ACP',
 });
 
 // Or use the convenience method that creates one only if needed
-const permit2 = await client.permits.getOrCreateSelfPermit();
+const acp2 = await client.acp.getOrCreateSelfACP();
 
-// Use with decryptForView (active permit is used automatically)
+// Use with decryptForView (active ACP is used automatically)
 const value = await client
   .decryptForView(ctHash, FheTypes.Uint32)
   .execute();
@@ -334,7 +334,7 @@ try {
 | `cofhejs/node` | `@cofhe/sdk/node` |
 | `cofhejs/web` | `@cofhe/sdk/web` |
 | N/A | `@cofhe/sdk` (core types, `Encryptable`, `FheTypes`) |
-| N/A | `@cofhe/sdk/permits` |
+| N/A | `@cofhe/sdk/acps` |
 | N/A | `@cofhe/sdk/adapters` |
 | N/A | `@cofhe/sdk/chains` |
 

--- a/client-sdk/introduction/overview.mdx
+++ b/client-sdk/introduction/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: "Introduction to @cofhe/sdk - the TypeScript client SDK for building FHE-enabled applications on Fhenix"
 ---
 
-`@cofhe/sdk` is the TypeScript client SDK for [CoFHE](/deep-dive/cofhe-components/overview). It handles the client-side operations required to interact with FHE-enabled smart contracts: encrypting inputs with ZK proofs, decrypting ciphertext handles via the Threshold Network, and managing EIP-712 permits for access control.
+`@cofhe/sdk` is the TypeScript client SDK for [CoFHE](/deep-dive/cofhe-components/overview). It handles the client-side operations required to interact with FHE-enabled smart contracts: encrypting inputs with ZK proofs, decrypting ciphertext handles via the Threshold Network, and managing EIP-712 ACPs (Access Control Permissions, formerly permits) for access control.
 
 On-chain, contracts use [`FHE.sol`](/fhe-library/introduction/overview) to operate on encrypted data. Off-chain, this SDK prepares the inputs and reads the outputs.
 
@@ -16,15 +16,15 @@ On-chain, contracts use [`FHE.sol`](/fhe-library/introduction/overview) to opera
 </Card>
 
 <Card title="Decrypt for View" icon="eye">
-  Requests decryption of a ciphertext handle via the Threshold Network using a permit. Returns the plaintext locally, not published on-chain.
+  Requests decryption of a ciphertext handle via the Threshold Network using an ACP. Returns the plaintext locally, not published onchain.
 </Card>
 
 <Card title="Decrypt for Tx" icon="arrow-right-arrow-left">
-  Requests decryption and returns the plaintext with a Threshold Network signature for on-chain verification.
+  Requests decryption and returns the plaintext with a Threshold Network signature for onchain verification.
 </Card>
 
-<Card title="Manage Permits" icon="id-card">
-  Creates, stores, and manages EIP-712 permits that authorize decryption of specific ciphertext handles.
+<Card title="Manage ACPs" icon="id-card">
+  Creates, stores, and manages EIP-712 ACPs that authorize decryption of specific ciphertext handles.
 </Card>
 
 </CardGroup>
@@ -36,7 +36,7 @@ On-chain, contracts use [`FHE.sol`](/fhe-library/introduction/overview) to opera
 | `@cofhe/sdk` | Core types (`Encryptable`, `FheTypes`, `EncryptStep`, `CofheError`), shared across runtimes |
 | `@cofhe/sdk/web` | `createCofheConfig` / `createCofheClient` with browser defaults (IndexedDB storage, TFHE WASM, Web Workers) |
 | `@cofhe/sdk/node` | `createCofheConfig` / `createCofheClient` with Node.js defaults (filesystem storage, `node-tfhe`) |
-| `@cofhe/sdk/permits` | Permit creation, validation, serialization, and storage utilities |
+| `@cofhe/sdk/acps` | ACP creation, validation, serialization, and storage utilities |
 | `@cofhe/sdk/adapters` | `Ethers5Adapter`, `Ethers6Adapter`, `WagmiAdapter`, `HardhatSignerAdapter` |
 | `@cofhe/sdk/chains` | Built-in chain definitions and `getChainById` / `getChainByName` helpers |
 
@@ -58,10 +58,10 @@ import { Ethers6Adapter } from '@cofhe/sdk/adapters';
 
 ## Client lifecycle
 
-The SDK follows a three-step lifecycle: **config → client → connect**.
+The SDK follows a three-step lifecycle: **config, client, then connect**.
 
-```
-createCofheConfig({ supportedChains }) → createCofheClient(config) → client.connect(publicClient, walletClient)
+```text
+createCofheConfig({ supportedChains }), then createCofheClient(config), then client.connect(publicClient, walletClient)
 ```
 
 ```typescript
@@ -82,7 +82,7 @@ const [encrypted] = await client
 await contract.deposit(encrypted);
 
 // Decrypt for UI
-await client.permits.getOrCreateSelfPermit();
+await client.acp.getOrCreateSelfACP();
 const ctHash = await contract.getBalance();
 const balance = await client
   .decryptForView(ctHash, FheTypes.Uint64)
@@ -94,19 +94,19 @@ const balance = await client
 <CardGroup cols={2}>
 
 <Card title="Quick Start" icon="rocket" href="/client-sdk/quick-start">
-  Install the SDK, write a contract, and run your first encrypt → store → decrypt test in minutes.
+  Install the SDK, write a contract, and run your first encrypt, store, and decrypt test in minutes.
 </Card>
 
 <Card title="Encrypting Inputs" icon="lock" href="/client-sdk/guides/encrypting-inputs">
   Encrypt plaintext values with ZK proofs before passing them to your smart contract.
 </Card>
 
-<Card title="Permits" icon="id-card" href="/client-sdk/guides/permits">
-  Create and manage EIP-712 permits that authorize decryption of confidential data.
+<Card title="ACPs" icon="id-card" href="/client-sdk/guides/permits">
+  Create and manage EIP-712 ACPs that authorize decryption of confidential data.
 </Card>
 
 <Card title="Decrypt to View" icon="eye" href="/client-sdk/guides/decrypt-to-view">
-  Reveal encrypted values locally for UI display using permits.
+  Reveal encrypted values locally for UI display using ACPs.
 </Card>
 
 <Card title="Decrypt to Transact" icon="arrow-right-arrow-left" href="/client-sdk/guides/decrypt-to-tx">

--- a/client-sdk/quick-start/javascript.mdx
+++ b/client-sdk/quick-start/javascript.mdx
@@ -3,7 +3,7 @@ title: "Quick Start: JavaScript"
 description: "Get started with @cofhe/sdk in a browser or Node.js app"
 ---
 
-Connect to an FHE-enabled contract, encrypt a value, send it on-chain, and decrypt the result — all from JavaScript.
+Connect to an FHE-enabled contract, encrypt a value, send it onchain, and decrypt the result, all from JavaScript.
 
 ## Prerequisites
 
@@ -115,8 +115,8 @@ await contract.setValue(encrypted);
 ```typescript
 import { FheTypes } from '@cofhe/sdk';
 
-// Create a permit (one-time per account + chain)
-await client.permits.getOrCreateSelfPermit();
+// Create an ACP (one-time per account + chain)
+await client.acp.getOrCreateSelfACP();
 
 // Read the encrypted handle from your contract
 const ctHash = await contract.storedValue();
@@ -131,8 +131,8 @@ console.log(plaintext); // 42n
 
 ## Next steps
 
-- [Client Setup](/client-sdk/guides/client-setup) — adapters, connection management, and config options.
-- [Encrypting Inputs](/client-sdk/guides/encrypting-inputs) — supported types, builder API, and progress callbacks.
-- [Permits](/client-sdk/guides/permits) — create, share, and manage decryption authorization.
-- [Decrypt to View](/client-sdk/guides/decrypt-to-view) — reveal encrypted state in your UI.
-- [Decrypt to Transact](/client-sdk/guides/decrypt-to-tx) — decrypt with a verifiable signature for on-chain use.
+- [Client Setup](/client-sdk/guides/client-setup): adapters, connection management, and config options.
+- [Encrypting Inputs](/client-sdk/guides/encrypting-inputs): supported types, builder API, and progress callbacks.
+- [ACPs](/client-sdk/guides/permits): create, share, and manage decryption authorization (formerly permits).
+- [Decrypt to View](/client-sdk/guides/decrypt-to-view): reveal encrypted state in your UI.
+- [Decrypt to Transact](/client-sdk/guides/decrypt-to-tx): decrypt with a verifiable signature for onchain use.

--- a/client-sdk/reference/foundry-reference.mdx
+++ b/client-sdk/reference/foundry-reference.mdx
@@ -28,7 +28,7 @@ import { CofheTest } from "@cofhe/foundry-plugin/contracts/CofheTest.sol";
 | --- | --- |
 | `getPlaintext(bytes32 handle)` | Returns the raw `bytes32` plaintext from `MockTaskManager.mockStorage`. |
 | `getPlaintext(ebool)` / `(euint8)` / `(euint16)` / `(euint32)` / `(euint64)` / `(euint128)` / `(eaddress)` | Typed overloads returning `bool` / `uint8`–`uint128` / `address`. |
-| `expectPlaintext(handle, value)` | Assertion variant — typed overloads for the same set. |
+| `expectPlaintext(handle, value)` | Assertion variant: typed overloads for the same set. |
 | `expectPlaintext(handle, value, "msg")` | With assertion message. |
 
 Reverts if the handle isn't in mock storage.
@@ -63,7 +63,7 @@ import { CofheClient } from "@cofhe/foundry-plugin/contracts/CofheClient.sol";
 
 | Function | Description |
 | --- | --- |
-| `connect(uint256 pkey)` | Set the connected account to `vm.addr(pkey)`. Required before any `createIn*` or `permit_*` call. |
+| `connect(uint256 pkey)` | Set the connected account to `vm.addr(pkey)`. Required before any `createIn*` or `ACP_*` call. |
 | `account()` | Returns the connected `address`. |
 
 ### Encrypt inputs
@@ -84,23 +84,23 @@ All produce signed `EncryptedInput` shapes signed for `account()`.
 
 | Function | Returns | Notes |
 | --- | --- | --- |
-| `decryptForTx_withoutPermit(bytes32 ctHash)` | `(bytes32, uint256, bytes)` | `(ctHash, plaintext, signature)`. Signature consumable by `FHE.publishDecryptResult`. Requires `FHE.allowPublic(handle)` to have been called. |
-| `decryptForTx_withPermit(bytes32 ctHash, Permission permit)` | `(bytes32, uint256, bytes)` | ACL-gated `decryptForTx`. |
-| `decryptForView(bytes32 ctHash, Permission permit)` | `uint256` | Off-chain seal/unseal. **Reverts on deny** — to assert deny use `mockThresholdNetwork.querySealOutput(...)`. |
+| `decryptForTx_withoutACP(bytes32 ctHash)` | `(bytes32, uint256, bytes)` | `(ctHash, plaintext, signature)`. Signature consumable by `FHE.publishDecryptResult`. Requires `FHE.allowPublic(handle)` to have been called. |
+| `decryptForTx_withACP(bytes32 ctHash, ACP acp)` | `(bytes32, uint256, bytes)` | ACL-gated `decryptForTx`. |
+| `decryptForView(bytes32 ctHash, ACP acp)` | `uint256` | Offchain seal/unseal. **Reverts on deny**: to assert deny use `mockThresholdNetwork.querySealOutput(...)`. |
 
-### Permits
+### ACPs
 
 | Function | Description |
 | --- | --- |
-| `permit_createSelf()` | Self-permit for the connected account; sealing key auto-derived. |
-| `permit_createShared(address recipient)` | Issuer-side shared permit. |
-| `permit_exportShared(Permission perm)` | Strip sensitive fields → `SharedPermitExport`. |
-| `permit_importShared(SharedPermitExport export)` | Recipient-side completion. Reverts unless `export.recipient == account()`. |
-| `createSealingKey(bytes32 seed)` | Custom sealing key (rarely needed). |
+| `ACP_createSelf()` | Self ACP for the connected account; sealing key auto-derived. |
+| `ACP_createShared(address recipient)` | Issuer-side shared ACP. |
+| `ACP_exportShared(ACP acp)` | Strip sensitive fields to `SharedACPExport`. |
+| `ACP_importShared(SharedACPExport export)` | Recipient-side completion. Reverts unless `export.recipient == account()`. |
+| `createSealingKey(uint256 seed)` | Custom sealing key (rarely needed). |
 
 ## Mock storage layout
 
-`MockTaskManager.mockStorage` is the on-chain plaintext storage that backs `getPlaintext` / `expectPlaintext`. It only exists in the mock environment — `getPlaintext` reverts on real CoFHE networks.
+`MockTaskManager.mockStorage` is the onchain plaintext storage that backs `getPlaintext` / `expectPlaintext`. It only exists in the mock environment: `getPlaintext` reverts on real CoFHE networks.
 
 ## `foundry.toml` requirements
 
@@ -113,7 +113,7 @@ libs = ["node_modules"]
 ```
 
 <Note>
-`evm_version = "cancun"` is no longer required as of `@cofhe/mock-contracts@0.5.0` — `MockACL` was migrated off transient storage to block-number-based storage. Set it only if your own contracts need cancun-specific opcodes.
+`evm_version = "cancun"` is no longer required as of `@cofhe/mock-contracts@0.5.0`: `MockACL` was migrated off transient storage to block-number-based storage. Set it only if your own contracts need cancun-specific opcodes.
 </Note>
 
 ## `remappings.txt` (canonical shape)
@@ -132,7 +132,7 @@ hardhat/=node_modules/forge-std/src/
 
 ## Version pinning
 
-`@cofhe/foundry-plugin` and `@cofhe/mock-contracts` pin `@fhenixprotocol/cofhe-contracts` *exactly* — keep all three CoFHE packages aligned. Known-good tuple as of the latest release:
+`@cofhe/foundry-plugin` and `@cofhe/mock-contracts` pin `@fhenixprotocol/cofhe-contracts` *exactly*: keep all three CoFHE packages aligned. Known-good tuple as of the latest release:
 
 | Package | Version |
 | --- | --- |


### PR DESCRIPTION
## Summary
- `@cofhe/sdk@0.7.0` removed the permit surface (`client.permits`, `@cofhe/sdk/permits`, `PermitUtils`, `withPermit` / `withoutPermit`).
- Updated the Client SDK guides and examples to `client.acp` / `ACPUtils` / `withACP` / `withoutACP`, and Foundry helpers to `ACP_*` / `decryptForTx_withoutACP`.
- Left `error-handling.mdx` and `sdk-reference.mdx` alone (open PRs #42 / #41 already cover them).

## Files
- `client-sdk/guides/permits.mdx` (content → ACPs; path unchanged)
- `client-sdk/guides/decrypt-to-tx.mdx`, `decrypt-to-view.mdx`
- Foundry / Hardhat testing pages, overview, mental model, end-to-end, JS quick start, migrating-from-cofhejs, templates

## Test plan
- [ ] Snippets use only names present in `@cofhe/sdk@0.7.0` types (`getOrCreateSelfACP`, `@cofhe/sdk/acps`, `.withACP()`)
- [ ] No remaining `getOrCreateSelfPermit` / `@cofhe/sdk/permits` / `withPermit` outside the intentionally untouched pages
- [ ] `scripts/lint-docs.py` clean on touched guides