### PR TITLE
docs: add Base Sepolia deployment steps and fix client SDK link

### DIFF
--- a/fhe-library/introduction/quick-start.mdx
+++ b/fhe-library/introduction/quick-start.mdx
@@ -182,6 +182,7 @@ Create a `.env` file with your private key and RPC URLs:
 PRIVATE_KEY=your_private_key_here
 SEPOLIA_RPC_URL=your_sepolia_rpc_url
 ARBITRUM_SEPOLIA_RPC_URL=your_arbitrum_sepolia_rpc_url
+BASE_SEPOLIA_RPC_URL=your_base_sepolia_rpc_url
 ```
 
 <Warning>
@@ -200,6 +201,10 @@ pnpm eth-sepolia:deploy-counter
 ```bash Arbitrum Sepolia
 pnpm arb-sepolia:deploy-counter
 ```
+
+```bash Base Sepolia
+pnpm base-sepolia:deploy-counter
+```
 </CodeGroup>
 </Step>
 
@@ -213,6 +218,10 @@ pnpm eth-sepolia:increment-counter
 
 ```bash Arbitrum Sepolia
 pnpm arb-sepolia:increment-counter
+```
+
+```bash Base Sepolia
+pnpm base-sepolia:increment-counter
 ```
 </CodeGroup>
 </Step>
@@ -270,7 +279,7 @@ CoFHE supports multiple development environments:
 
 - Public testnet for real FHE operations
 - Requires ETH from the Sepolia faucet
-- Available on Ethereum Sepolia and Arbitrum Sepolia
+- Available on Ethereum Sepolia, Arbitrum Sepolia, and Base Sepolia
 
 <Info>
 Environment detection happens automatically in most cases. When testing on the Hardhat network with mocks deployed (e.g., in unit tests), `hre.cofhe.createClientWithBatteries` will detect the Hardhat network and configure the client for the mock environment. When using tasks that connect to networks like `arb-sepolia`, the environment will automatically be set to testnet mode. This environment setting is crucial as it determines how the SDK handles encryption and decryption operations.
@@ -323,7 +332,7 @@ Now that you have your development environment set up, you can:
 
 - Explore the [FHE Library documentation](/fhe-library) to learn about encrypted data types and operations
 - Review the [Counter contract example](https://github.com/FhenixProtocol/cofhe-hardhat-starter/blob/main/contracts/Counter.sol) to see FHE in action
-- Check out the [Client SDK documentation](/client-sdk/introduction/overview) for client-side integration
+- Check out the [Client SDK documentation](/cofhejs/introduction/overview) for client-side integration
 - Learn about [access control mechanisms](/fhe-library) for managing encrypted data permissions
 
 ## Resources


### PR DESCRIPTION
### Description

This PR improves `fhe-library/introduction/quick-start.mdx` with the following fixes and additions:

- **Base Sepolia Consistency:** Added `BASE_SEPOLIA_RPC_URL` to the `.env` example and included `Base Sepolia` deployment and task interaction snippets in the CodeGroups (`pnpm base-sepolia:deploy-counter` and `pnpm base-sepolia:increment-counter`) for full consistency with the **Supported Networks** section.
- **Testnet Scope Update:** Added Base Sepolia to the **Sepolia Testnet** environment description.
- **Broken Internal Link Fix:** Updated the Client SDK documentation route in the **Next Steps** section from `/client-sdk/introduction/overview` to `/cofhejs/introduction/overview`.

### Checklist
- [x] Verified markdown formatting and CodeGroup tabs
- [x] Fixed broken internal route
- [x] Maintained consistency with supported networks list