### PR TITLE
[DOCS] ci/mint-check: add mint validate and broken-links workflow

### DIFF
--- a/.github/workflows/mint-check.yml
+++ b/.github/workflows/mint-check.yml
@@ -1,0 +1,53 @@
+name: Mint check
+
+on:
+  pull_request:
+    paths:
+      - '**/*.mdx'
+      - '**/*.md'
+      - 'docs.json'
+  workflow_dispatch:
+
+# A force-push supersedes the previous run; the site-wide checks take long
+# enough that letting both finish wastes minutes for no signal.
+concurrency:
+  group: mint-check-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MINT_VERSION: 4.2.819
+  # mint depends on puppeteer, whose postinstall downloads ~200 MB of Chrome.
+  # validate and broken-links never open a browser, so skip it: the download is
+  # the slowest step in the job and the one most likely to fail on a bad network.
+  PUPPETEER_SKIP_DOWNLOAD: true
+
+jobs:
+  mint:
+    name: validate + broken-links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Pinned, like Vale in docs-style.yml. The CLI ships several releases a
+      # week and validation rules change with it, so an unpinned install turns
+      # unrelated pull requests red. Bumping this is a deliberate commit.
+      - name: Install Mint CLI
+        run: |
+          npm install -g "mint@${MINT_VERSION}"
+          mint --version
+
+      # Both commands read the whole site, and neither takes file arguments,
+      # so they judge the build as it will ship, not just the changed pages.
+      - name: mint validate
+        run: mint validate
+
+      # External links stay unchecked: they would put the job on the network and
+      # make it fail for reasons no pull request introduced.
+      - name: mint broken-links
+        if: ${{ !cancelled() }}
+        run: mint broken-links --check-redirects --check-snippets

--- a/.github/workflows/mint-check.yml
+++ b/.github/workflows/mint-check.yml
@@ -48,6 +48,15 @@ jobs:
 
       # External links stay unchecked: they would put the job on the network and
       # make it fail for reasons no pull request introduced.
+      #
+      # --check-snippets covers links inside <Snippet> components. No page uses
+      # one today, so it currently changes nothing; it is here so the coverage
+      # arrives with the first snippet instead of being remembered afterwards.
+      # Files under snippets/ are already checked without it, being .mdx.
+      #
+      # The CLI ignores flags it does not recognise rather than failing, so a
+      # typo here fails open. Confirm a flag by breaking a link on purpose and
+      # watching the job go red, never by reading a green log.
       - name: mint broken-links
         if: ${{ !cancelled() }}
         run: mint broken-links --check-redirects --check-snippets

--- a/STYLE.md
+++ b/STYLE.md
@@ -98,7 +98,7 @@ Do not use internal names in public docs: no hostnames, no GCP project names, no
 ## Links, images, and components
 
 - Internal links use root-relative paths: `/fhe-library/core-concepts/access-control`, not `../core-concepts/access-control` and not the full `https://cofhe-docs.fhenix.zone/...` URL. Relative paths break when a page moves; absolute URLs break preview deployments.
-- Link text describes the destination. "See [access control](/fhe-library/core-concepts/access-control)", never "click [here](/...)" or a bare URL.
+- Link text describes the destination. "See [access control](/fhe-library/core-concepts/access-control)", never `"click [here](/...)"` or a bare URL.
 - Every image is wrapped in `<Frame>` and carries alt text that says what the image shows, not what it is called. "Sealed output flowing from the FHE Engine to the client", not "diagram".
 - Pick the component that matches the content, and use each one for one job:
 


### PR DESCRIPTION
Adds a `Mint check` workflow that runs the Mint CLI on pull requests touching docs content.

**1 of 2 in a stack.** Follow-up: #49 (fixes two broken anchors and turns on `--check-anchors`).

## What runs

`mint validate` (strict build validation) and `mint broken-links --check-redirects --check-snippets`. Both verified locally against the current site on the pinned CLI version: `build validation passed`, `no broken links found`.

`--check-redirects` enforces the CLAUDE.md rule that renaming or removing a page requires a redirect entry. Verified by pointing a redirect at a missing page: reported only with the flag.

`--check-snippets` covers links inside `<Snippet>` **components**, not files under `snippets/` (those are `.mdx` and are checked without it). No page uses a snippet today, so **the flag is a no-op here** and is kept only so the coverage arrives with the first one. An earlier revision of this description claimed it covered `snippets/`; that was wrong.

`--check-external` stays off (its default) so the job never fails for a third-party outage.

**Worth knowing when reviewing the flag list:** the CLI ignores flags it does not recognise instead of erroring (`--check-bogus-nonsense` exits 0 with `success no broken links found`), so a typo fails open. Flag names here were each verified by breaking a link on purpose, not by reading a green log. The workflow comment records this.

## Notes for review

- **The CLI is pinned** (`MINT_VERSION: 4.2.819`), matching how `docs-style.yml` pins Vale. Mint ships several releases a week and validation rules move with them, so an unpinned install would turn unrelated pull requests red. Bumping it is a deliberate commit.
- **`PUPPETEER_SKIP_DOWNLOAD: true`** — `mint` depends on puppeteer, whose postinstall pulls ~200 MB of Chrome on every run. Neither command opens a browser; both were verified with the download skipped.
- **No changed-file gating.** Neither command accepts file arguments; both always read the whole site. A `git diff` step could only decide *whether* to run, which the `paths:` trigger filter already decides, so it would be dead code plus a full-history clone. Whole-site checking is also the right semantics here: build validity and link integrity are global properties, unlike the per-file prose linting in `docs-style.yml`.
- `if: ${{ !cancelled() }}` rather than `always()`, so link results still appear when validate fails but a cancelled run actually stops.

## One content fix rides along

`STYLE.md:101` documents the "click [here](/...)" anti-pattern, and Mint parses that example as a real link to `/...`. It was the only broken link on the site and would have made this workflow red on its first run. Backticking it also matches how the path examples on the line above are already written. `STYLE.md` is exempt from Vale, so this does not touch the prose linter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

