### PR TITLE
[DOCS] client-sdk/foundry-plugin: fix deny-path anchors, clear STYLE.md backlog, enforce --check-anchors

### DIFF
--- a/.github/workflows/mint-check.yml
+++ b/.github/workflows/mint-check.yml
@@ -57,7 +57,7 @@ jobs:
       # --check-snippets covers links inside <Snippet> components. No page uses
       # one today, so it currently changes nothing; it is here so the coverage
       # arrives with the first snippet instead of being remembered afterwards.
-      # Files under snippets/ are already checked without it, being .mdx.
+      # A snippet file is checked without it anyway, being .mdx like any page.
       #
       # The CLI ignores flags it does not recognise rather than failing, so a
       # typo here fails open. Confirm a flag by breaking a link on purpose and

--- a/.github/workflows/mint-check.yml
+++ b/.github/workflows/mint-check.yml
@@ -49,6 +49,11 @@ jobs:
       # External links stay unchecked: they would put the job on the network and
       # make it fail for reasons no pull request introduced.
       #
+      # --check-anchors means a heading rename cannot silently strand an inbound
+      # #fragment. Give headings you link to a stable {#custom-id} rather than
+      # relying on the generated slug, which keeps apostrophes and any numeric
+      # prefix and so is easy to hand-write wrongly.
+      #
       # --check-snippets covers links inside <Snippet> components. No page uses
       # one today, so it currently changes nothing; it is here so the coverage
       # arrives with the first snippet instead of being remembered afterwards.
@@ -59,4 +64,4 @@ jobs:
       # watching the job go red, never by reading a green log.
       - name: mint broken-links
         if: ${{ !cancelled() }}
-        run: mint broken-links --check-redirects --check-snippets
+        run: mint broken-links --check-anchors --check-redirects --check-snippets

--- a/client-sdk/foundry-plugin/cofhe-client.mdx
+++ b/client-sdk/foundry-plugin/cofhe-client.mdx
@@ -1,9 +1,9 @@
 ---
 title: CofheClient
-description: "The in-Solidity SDK shim — one client per user, produces encrypted inputs and signed permits"
+description: "The in-Solidity SDK shim: one client per user, produces encrypted inputs and signed permits"
 ---
 
-`CofheClient` is the Foundry plugin's in-Solidity SDK shim. One client per "user" in your scenario. The client carries a private key and produces encrypted inputs / signed permits **as if it were that user's frontend SDK** — no JS bridge required.
+`CofheClient` is the Foundry plugin's in-Solidity SDK shim. One client per "user" in your scenario. The client carries a private key and produces encrypted inputs / signed permits **as if it were that user's frontend SDK**, with no JS bridge required.
 
 ## Creating and connecting
 
@@ -14,9 +14,9 @@ CofheClient bob = createCofheClient();
 bob.connect(0xB0B);            // bob.account() == vm.addr(0xB0B)
 ```
 
-After `connect`, the client knows which address to sign as. All `createInEuintN` and `permit_*` calls use that account automatically — there's no `account` argument to pass.
+After `connect`, the client knows which address to sign as. All `createInEuintN` and `permit_*` calls use that account automatically; there's no `account` argument to pass.
 
-To act on-chain as that user, prank with `client.account()`:
+To act onchain as that user, prank with `client.account()`:
 
 ```solidity
 vm.prank(bob.account());
@@ -24,12 +24,12 @@ counter.reset(bob.createInEuint32(2000));
 ```
 
 <Warning>
-A mismatch between the prank address and the client that produced the input will fail the ZK-verifier signature check — the input was signed for `bob.account()`, not whoever you pranked. Always match the client to the prank.
+A mismatch between the prank address and the client that produced the input will fail the ZK-verifier signature check. The input was signed for `bob.account()`, not whoever you pranked. Always match the client to the prank.
 </Warning>
 
 ## Encrypting inputs
 
-The client mirrors the JS SDK's `encryptInputs` API — one method per encrypted Solidity type:
+The client mirrors the JS SDK's `encryptInputs` API, one method per encrypted Solidity type:
 
 | Method | Returns |
 | --- | --- |
@@ -41,7 +41,7 @@ The client mirrors the JS SDK's `encryptInputs` API — one method per encrypted
 | `createInEuint128(uint128)` | `InEuint128` |
 | `createInEaddress(address)` | `InEaddress` |
 
-All produce signed `EncryptedInput` shapes — drop straight into the `InEuintN` parameter on the contract under test.
+All produce signed `EncryptedInput` shapes that drop straight into the `InEuintN` parameter on the contract under test.
 
 ```solidity
 InEuint32 memory encrypted = bob.createInEuint32(42);
@@ -58,9 +58,9 @@ The plugin exposes both decryption flows the SDK supports:
 | --- | --- | --- |
 | `decryptForTx_withoutPermit(ctHash)` | `(bytes32 ctHash, uint256 plaintext, bytes signature)` | Globally-allowed (`FHE.allowPublic`) ciphertexts. Pass `signature` to `FHE.publishDecryptResult`. |
 | `decryptForTx_withPermit(ctHash, permit)` | `(bytes32, uint256, bytes)` | ACL-gated `decryptForTx` flow. |
-| `decryptForView(ctHash, permit)` | `uint256 plaintext` | Off-chain seal/unseal flow. **Reverts on deny** — use the mock directly to assert deny. |
+| `decryptForView(ctHash, permit)` | `uint256 plaintext` | Offchain seal/unseal flow. **Reverts on deny**, so use the mock directly to assert deny. |
 
-### `decryptForTx_withoutPermit` — public-decrypt 3-step flow
+### Public-decrypt 3-step flow with `decryptForTx_withoutPermit`
 
 Mirrors the production flow when a contract calls `FHE.publishDecryptResult`:
 
@@ -77,9 +77,9 @@ bytes32 ctHash = euint32.unwrap(counter.count());
 counter.revealCounter(uint32(plaintext), sig);
 ```
 
-The same shape runs unmodified against real CoFHE on testnet — the mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
+The same shape runs unmodified against real CoFHE on testnet. The mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
 
-### `decryptForView` — permit-based unseal
+### Permit-based unseal with `decryptForView`
 
 ```solidity
 Permission memory bobPermit = bob.permit_createSelf();
@@ -87,7 +87,7 @@ uint256 value = bob.decryptForView(ctHash, bobPermit);
 assertEq(value, 42);
 ```
 
-`decryptForView` reverts when the caller isn't on the ACL. To **assert** the deny path (e.g. "Alice should NOT be able to decrypt Bob's value"), drop down to the mock directly — see [Testing: Deny path](/client-sdk/foundry-plugin/testing#deny-path-asserting-alice-cannot-decrypt-bob-s-value).
+`decryptForView` reverts when the caller isn't on the ACL. To **assert** the deny path (e.g. "Alice should NOT be able to decrypt Bob's value"), drop down to the mock directly. See [Testing: Deny path](/client-sdk/foundry-plugin/testing#deny-path).
 
 ## Permits
 
@@ -96,10 +96,10 @@ The client signs EIP-712 permits against the ACL's domain. Two flavors:
 | Method | Purpose |
 | --- | --- |
 | `permit_createSelf()` | Self-permit for the connected account; sealing key is auto-derived (`keccak(address)`). |
-| `permit_createShared(recipient)` | Issuer half of a shared permit (no sealing key — the recipient adds it on import). |
-| `permit_exportShared(perm)` | Strip sensitive fields → `SharedPermitExport` (safe to transmit out-of-band). |
+| `permit_createShared(recipient)` | Issuer half of a shared permit (no sealing key; the recipient adds it on import). |
+| `permit_exportShared(perm)` | Strip sensitive fields to produce `SharedPermitExport` (safe to transmit out-of-band). |
 | `permit_importShared(export)` | Recipient-side completion: adds sealing key + recipient signature. Reverts unless `export.recipient == account()`. |
-| `createSealingKey(seed)` | Custom sealing key. Rarely needed — `permit_createSelf` derives one for you. |
+| `createSealingKey(seed)` | Custom sealing key. Rarely needed: `permit_createSelf` derives one for you. |
 
 ### Self-permit (most common)
 
@@ -108,9 +108,9 @@ Permission memory bobPermit = bob.permit_createSelf();
 uint256 plaintext = bob.decryptForView(ctHash, bobPermit);
 ```
 
-`permit_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs — all in one call.
+`permit_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs, all in one call.
 
-### Shared permits (issuer → recipient)
+### Shared permits (issuer to recipient)
 
 ```solidity
 // Bob (issuer) creates a permit shared to Alice (recipient)
@@ -123,13 +123,13 @@ SharedPermitExport memory exported = bob.permit_exportShared(shared);
 Permission memory aliceImported = alice.permit_importShared(exported);
 ```
 
-`permit_importShared` reverts unless the calling client's `account()` matches `export.recipient` — preventing Alice from importing a permit shared to someone else.
+`permit_importShared` reverts unless the calling client's `account()` matches `export.recipient`, preventing Alice from importing a permit shared to someone else.
 
 ## Common pitfalls
 
 <AccordionGroup>
 <Accordion title="Wrong client for the prank" icon="triangle-exclamation">
-`vm.prank(bob.account())` while the input came from `alice.createInEuintN(...)` fails ZK verification — the input was signed for Alice's address, not Bob's. Match the client to the prank.
+`vm.prank(bob.account())` while the input came from `alice.createInEuintN(...)` fails ZK verification. The input was signed for Alice's address, not Bob's. Match the client to the prank.
 </Accordion>
 
 <Accordion title="Stale handle reads" icon="rotate">
@@ -151,7 +151,7 @@ The `pkey` passed to `connect` must derive the address used as `permit.issuer`. 
 </Accordion>
 
 <Accordion title="`decryptForView` reverts on deny" icon="ban">
-Useful default — most tests want a hard failure when the caller isn't permitted. To assert "Alice cannot decrypt", call the mock's `querySealOutput` directly:
+Useful default: most tests want a hard failure when the caller isn't permitted. To assert "Alice cannot decrypt", call the mock's `querySealOutput` directly:
 
 ```solidity
 (bool allowed, string memory err, ) = mockThresholdNetwork.querySealOutput(
@@ -165,5 +165,5 @@ assertEq(err, "NotAllowed");
 
 ## Next steps
 
-- [Testing](/client-sdk/foundry-plugin/testing) — full test-writing patterns.
-- [CofheTest](/client-sdk/foundry-plugin/cofhe-test) — the test base contract that creates clients.
+- [Testing](/client-sdk/foundry-plugin/testing): full test-writing patterns.
+- [CofheTest](/client-sdk/foundry-plugin/cofhe-test): the test base contract that creates clients.

--- a/client-sdk/foundry-plugin/cofhe-test.mdx
+++ b/client-sdk/foundry-plugin/cofhe-test.mdx
@@ -1,9 +1,9 @@
 ---
 title: CofheTest
-description: "The CofheTest abstract base contract — deploys CoFHE mocks and exposes plaintext assertions"
+description: "The CofheTest abstract base contract: deploys CoFHE mocks and exposes plaintext assertions"
 ---
 
-`CofheTest` is the abstract test base shipped by `@cofhe/foundry-plugin`. It already inherits `forge-std/Test`, so inherit `CofheTest` directly — inheriting both is a redeclaration error.
+`CofheTest` is the abstract test base shipped by `@cofhe/foundry-plugin`. It already inherits `forge-std/Test`, so inherit `CofheTest` directly; inheriting both is a redeclaration error.
 
 ```solidity
 import { CofheTest } from "@cofhe/foundry-plugin/contracts/CofheTest.sol";
@@ -22,7 +22,7 @@ Call once in `setUp()`. Deploys the full CoFHE mock stack and wires the contract
 
 | Mock | Role | Address |
 | --- | --- | --- |
-| `MockTaskManager` | Manages FHE operations; stores plaintext values on-chain | `TASK_MANAGER_ADDRESS` (fixed) |
+| `MockTaskManager` | Manages FHE operations; stores plaintext values onchain | `TASK_MANAGER_ADDRESS` (fixed) |
 | `MockACL` | Access control list for encrypted handles | (deployed) |
 | `MockZkVerifier` | Verifies encrypted-input ZK proofs | `0x…5001` (fixed) |
 | `MockZkVerifierSigner` | Signs encrypted inputs (for the mock verifier) | (funded with 10 ether) |
@@ -40,7 +40,7 @@ mockThresholdNetwork
 mockThresholdNetworkSigner
 ```
 
-Reach into them when you need behavior `expectPlaintext` doesn't cover (e.g. permission-denied assertions — see [Testing](/client-sdk/foundry-plugin/testing#deny-path-asserting-alice-cannot-decrypt-bob-s-value)).
+Reach into them when you need behavior `expectPlaintext` doesn't cover (e.g. permission-denied assertions: see [Testing](/client-sdk/foundry-plugin/testing#deny-path)).
 
 ## `createCofheClient()`
 
@@ -55,11 +55,11 @@ One client per scenario address. Connecting with a deterministic plaintext priva
 
 ## Reading plaintext values
 
-Because `MockTaskManager` stores plaintext values on-chain, you can read the underlying plaintext of any encrypted handle directly — no permit needed.
+Because `MockTaskManager` stores plaintext values onchain, you can read the underlying plaintext of any encrypted handle directly, with no permit needed.
 
 ### `getPlaintext(handle)`
 
-Returns the on-chain plaintext from `MockTaskManager.mockStorage`. Typed overloads exist for every encrypted Solidity type:
+Returns the onchain plaintext from `MockTaskManager.mockStorage`. Typed overloads exist for every encrypted Solidity type:
 
 ```solidity
 bytes32 plaintext   = getPlaintext(handle);            // raw
@@ -76,7 +76,7 @@ Reverts if the handle isn't in mock storage.
 
 ### `expectPlaintext(handle, value)` and `(handle, value, "msg")`
 
-Assertion variant — typed overloads for the same type set. Faster than `decryptForView` (no SDK round-trip, no permit needed). Use it whenever you only care about the value, not the SDK code path.
+Assertion variant, with typed overloads for the same type set. Faster than `decryptForView` (no SDK round-trip, no permit needed). Use it whenever you only care about the value, not the SDK code path.
 
 ```solidity
 expectPlaintext(counter.count(), uint32(42));
@@ -96,7 +96,7 @@ The mocks log every FHE operation to the console when log mode is on. Toggle it 
 | `enableLogs()` | Calls `mockTaskManager.setLogOps(true)` |
 | `disableLogs()` | Calls `mockTaskManager.setLogOps(false)` |
 
-Logging is verbose — enable it only around the operation you're investigating.
+Logging is verbose, so enable it only around the operation you're investigating.
 
 ```solidity
 function test_DebuggingIncrement() public {
@@ -109,7 +109,7 @@ function test_DebuggingIncrement() public {
 
 Each operation prints in a formatted block:
 
-```
+```text
 ├ FHE.add          | euint32(4473..3424)[0] + euint32(1157..3648)[1]  =>  euint32(1106..1872)[1]
 ├ FHE.allowThis    | euint32(1106..1872)[1] -> 0x663f..6602
 ```
@@ -118,7 +118,7 @@ Each operation prints in a formatted block:
 
 <AccordionGroup>
 <Accordion title="IDE Solidity LSP errors but `forge test` is green" icon="triangle-exclamation">
-Solidity LSPs (Wake, Cursor, etc.) often resolve imports from the monorepo root rather than the package's `node_modules`. The plugin's remappings are package-local, so the LSP may flag valid imports. **`forge` is authoritative** — if `forge build` and `forge test` succeed, the test is correct.
+Solidity LSPs (Wake, Cursor, etc.) often resolve imports from the monorepo root rather than the package's `node_modules`. The plugin's remappings are package-local, so the LSP may flag valid imports. **`forge` is authoritative.** If `forge build` and `forge test` succeed, the test is correct.
 </Accordion>
 
 <Accordion title="`@cofhe/mock-contracts/foundry/CoFheTest.sol` import" icon="circle-xmark">
@@ -132,11 +132,11 @@ See the [migration mapping](/client-sdk/foundry-plugin/testing#migration-from-th
 </Accordion>
 
 <Accordion title="Don't run `forge test` cross-monorepo" icon="folder">
-The remappings are relative to the foundry package's root. Running `forge test` from a parent monorepo directory won't resolve them — `forge` resolves from the working directory.
+The remappings are relative to the foundry package's root. Running `forge test` from a parent monorepo directory won't resolve them; `forge` resolves from the working directory.
 </Accordion>
 </AccordionGroup>
 
 ## Next steps
 
-- [CofheClient](/client-sdk/foundry-plugin/cofhe-client) — per-user encrypt / decrypt / permit shim.
-- [Testing](/client-sdk/foundry-plugin/testing) — canonical test-writing patterns and migration mapping.
+- [CofheClient](/client-sdk/foundry-plugin/cofhe-client): per-user encrypt / decrypt / permit shim.
+- [Testing](/client-sdk/foundry-plugin/testing): canonical test-writing patterns and migration mapping.

--- a/client-sdk/foundry-plugin/testing.mdx
+++ b/client-sdk/foundry-plugin/testing.mdx
@@ -3,7 +3,7 @@ title: Testing
 description: "Canonical test-writing patterns for FHE contracts under Foundry"
 ---
 
-This page shows the load-bearing patterns for writing FHE contract tests under Foundry with `@cofhe/foundry-plugin`. Hardhat counterpart: [Hardhat Plugin → Testing](/client-sdk/hardhat-plugin/testing).
+This page shows the load-bearing patterns for writing FHE contract tests under Foundry with `@cofhe/foundry-plugin`. Hardhat counterpart: [Hardhat Plugin: Testing](/client-sdk/hardhat-plugin/testing).
 
 ## Skeleton
 
@@ -39,7 +39,7 @@ contract CounterTest is CofheTest {
 }
 ```
 
-That's the load-bearing shape. Everything below is what to add when the contract gets non-trivial.
+That's the load-bearing shape. Everything below is what to add as the contract grows more complex.
 
 ## Rules
 
@@ -49,16 +49,16 @@ That's the load-bearing shape. Everything below is what to add when the contract
 
 ### 2. One `CofheClient` per scenario address
 
-Each user with their own permit/encrypted inputs gets their own client. Connect with a deterministic plaintext private key — don't recycle real keys; these are visible in test output.
+Each user with their own permit/encrypted inputs gets their own client. Connect with a deterministic plaintext private key. Don't recycle real keys; these are visible in test output.
 
 ```solidity
 CofheClient bob = createCofheClient();
 bob.connect(0xB0B);         // bob.account() == vm.addr(0xB0B)
 ```
 
-You don't pass `account` to `createInEuintN` — the client is bound at `connect`.
+You don't pass `account` to `createInEuintN`; the client is bound at `connect`.
 
-### 3. `vm.prank(client.account())` to act on-chain as that user
+### 3. `vm.prank(client.account())` to act onchain as that user
 
 ```solidity
 vm.prank(bob.account());
@@ -93,7 +93,7 @@ counter.revealCounter(uint32(plaintext), sig);
 assertEq(counter.getDecryptedValue(), plaintext);
 ```
 
-Same shape runs unmodified against real CoFHE on testnet — the mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
+Same shape runs unmodified against real CoFHE on testnet. The mock signature is produced by the same `MockThresholdNetworkSigner` that `FHE.verifyDecryptResult` accepts.
 
 ### 6. Permit-based unseal: `decryptForView` for the success path
 
@@ -105,9 +105,9 @@ uint256 value = bob.decryptForView(ctHash, bobPermit);
 assertEq(value, expected);
 ```
 
-`permit_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs — no manual `signPermissionSelf` boilerplate.
+`permit_createSelf` builds the EIP-712 typed-data, derives a sealing key from the connected account, and signs, with no manual `signPermissionSelf` boilerplate.
 
-### 7. Deny path: asserting "Alice cannot decrypt Bob's value"
+### 7. Deny path: when the caller is not on the ACL {#deny-path}
 
 `decryptForView` reverts when the caller isn't on the ACL. To assert the deny path, drop down to the mock directly:
 
@@ -133,7 +133,7 @@ function testFuzz_Reset(uint32 v) public {
 }
 ```
 
-`createInEuintN` accepts the full `uintN` range — no shaping needed.
+`createInEuintN` accepts the full `uintN` range, so no shaping needed.
 
 ## Migration from the old `mock-contracts` API
 
@@ -147,7 +147,7 @@ If you're upgrading from `@cofhe/mock-contracts@0.4.x` (where `CoFheTest` lived 
 | `mockStorage(ctHash)` | `getPlaintext(ctHash)` |
 | `createInEuint32(v, bob)` | `bob.createInEuint32(v)` |
 | `createPermissionSelf(bob)` + `signPermissionSelf(perm, bobKey)` | `bob.permit_createSelf()` (auto-signs) |
-| `createSealingKey(seed)` | `bob.createSealingKey(seed)` (rarely needed — `permit_createSelf` derives one) |
+| `createSealingKey(seed)` | `bob.createSealingKey(seed)` (rarely needed: `permit_createSelf` derives one) |
 | `queryDecrypt(hash, chainId, permit)` | `bob.decryptForView(hash, permit)` (reverts on deny) |
 | Same, asserting deny | `mockThresholdNetwork.querySealOutput(hash, block.chainid, permit)` |
 | `querySealOutput` + `unseal` | `bob.decryptForView` (does both) |
@@ -157,11 +157,11 @@ If you're upgrading from `@cofhe/mock-contracts@0.4.x` (where `CoFheTest` lived 
 
 <AccordionGroup>
 <Accordion title="IDE Solidity errors but `forge test` passes" icon="triangle-exclamation">
-LSPs like Wake/Cursor often resolve from the monorepo root; the plugin's remappings are package-local. **`forge` is the truth** — if `forge build` and `forge test` succeed, the test is correct.
+LSPs like Wake/Cursor often resolve from the monorepo root; the plugin's remappings are package-local. **`forge` is the truth.** If `forge build` and `forge test` succeed, the test is correct.
 </Accordion>
 
 <Accordion title="Forgetting `FHE.allowThis` in the contract" icon="key">
-Tests pass on the first op, then a second op reverts with `ACLNotAllowed` because the contract itself isn't on the ACL. Toggle `enableLogs()` to see the missing grant — every op prints a line showing whether `allowThis`/`allow` was called.
+Tests pass on the first op, then a second op reverts with `ACLNotAllowed` because the contract itself isn't on the ACL. Toggle `enableLogs()` to see the missing grant. Every op prints a line showing whether `allowThis`/`allow` was called.
 </Accordion>
 
 <Accordion title="Wrong client for the prank" icon="user">
@@ -188,6 +188,6 @@ The `pkey` passed to `connect` must derive the address used as `permit.issuer`. 
 
 ## Related
 
-- [CofheTest](/client-sdk/foundry-plugin/cofhe-test) — the test base contract API.
-- [CofheClient](/client-sdk/foundry-plugin/cofhe-client) — the per-user shim API.
-- [Hardhat → Testing](/client-sdk/hardhat-plugin/testing) — the same patterns under Hardhat.
+- [CofheTest](/client-sdk/foundry-plugin/cofhe-test): the test base contract API.
+- [CofheClient](/client-sdk/foundry-plugin/cofhe-client): the per-user shim API.
+- [Testing under Hardhat](/client-sdk/hardhat-plugin/testing): the same patterns for Hardhat.

--- a/snippets/snippet-intro.mdx
+++ b/snippets/snippet-intro.mdx
@@ -1,4 +1,0 @@
-One of the core principles of software development is DRY (Don't Repeat
-Yourself). This is a principle that applies to documentation as
-well. If you find yourself repeating the same content in multiple places, you
-should consider creating a custom snippet to keep your content in sync.


### PR DESCRIPTION
**2 of 2 in a stack. Targets `ci/mint-check` (#48), not `main`** — review that one first, and this diff will shrink to its own commits once #48 merges.

## The bug

`cofhe-client.mdx` and `cofhe-test.mdx` both linked to:

```
/client-sdk/foundry-plugin/testing#deny-path-asserting-alice-cannot-decrypt-bob-s-value
```

That fragment never resolved. Mint does not use GitHub-style slugging: it keeps the apostrophe as a right single quotation mark and keeps the `7.` prefix, so the hand-written `bob-s` and the dropped number were both wrong. Two links readers hit today land nowhere.

The heading now carries a `{#deny-path}` custom ID, so the anchor is stable and renumbering the rule list cannot break it again. Nothing else on the site links to a heading on these pages, so no other anchors change.

## Why the prose changes are here

`docs-style.yml` lints the files a pull request touches. These three pages carried **48 Vale errors and 3 warnings** before this branch, so any pull request touching them failed on an unrelated backlog. Fixing the anchors meant clearing that first. All three pages are now at **0 errors, 0 warnings, 0 suggestions**, and `scripts/lint-docs.py` reports 0 errors.

The changes are mechanical against STYLE.md: em dashes rewritten as commas, periods, colons or parentheses; `on-chain`/`Off-chain` to `onchain`/`offchain`; decorative arrows replaced with words; one 30+ word sentence split; a `non-trivial` aside reworded; one untagged fence tagged `text`. Two headings that named a method after an em dash now read "Public-decrypt 3-step flow with `decryptForTx_withoutPermit`", matching how the Testing page already names the same flows and keeping them in sentence case. No technical claim changed.

This is a dent in a repo-wide backlog, not the end of it: 81 of 113 pages still have Vale violations.

## The workflow change

Adds `--check-anchors` to `mint broken-links`. These three pages were the only anchor failures on the site, so the check can be enforced rather than documented.

Verified end to end rather than by exit code: a deliberately broken fragment was pushed to a throwaway branch and the job failed on it in ~5s, naming the file and the fragment. This matters because the CLI ignores flags it does not recognise instead of erroring, so a green log is not evidence a flag took effect. The workflow comment records that.

## Unused snippet deleted

`snippets/snippet-intro.mdx` was Mintlify starter boilerplate about the DRY principle. No page included it, `docs.json` never referenced it, and it was not a published route, so no redirect is needed. Removing it empties `snippets/`.

`--check-snippets` stays on the command, as agreed: it is a no-op today but starts earning its place with the first real `<Snippet>`. Its comment no longer points at a directory that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
