### PR TITLE
[DOCS] get-started/compatibility: refresh versions, links, and network presets

### DIFF
--- a/get-started/introduction/compatibility.mdx
+++ b/get-started/introduction/compatibility.mdx
@@ -94,14 +94,6 @@ The [official migration guide](https://cofhesdk.fhenix.io/migrating-to-0-7-0) co
 ## Troubleshooting
 
 <AccordionGroup>
-<Accordion title="Install fails on @fhenixprotocol/fhenix-confidential-contracts" icon="circle-xmark">
-That package name does not exist. Install `fhenix-confidential-contracts` instead, without the scope.
-</Accordion>
-
-<Accordion title="Hardhat cannot find the eth-sepolia network" icon="network-wired">
-Both plugins register `eth-sepolia` only when your own config does not already define it. Confirm the plugin is imported in `hardhat.config.ts`, and that you are not shadowing the preset with an empty entry of the same name.
-</Accordion>
-
 <Accordion title="Encrypted inputs stop verifying after upgrading" icon="key">
 `0.7` signs one batch rather than one ciphertext, and the input types changed. A `0.6` client against `0.7` contracts fails verification. Upgrade both sides together.
 </Accordion>

--- a/get-started/introduction/compatibility.mdx
+++ b/get-started/introduction/compatibility.mdx
@@ -1,82 +1,114 @@
 ---
 title: "Compatibility"
-description: "Essential version information and network compatibility for all CoFHE ecosystem components"
+description: "Which package versions, toolchains, and networks work together"
 ---
 
-## Overview
-
-This document provides detailed compatibility information for all components in the CoFHE ecosystem. Following these version requirements is crucial for maintaining a stable and secure development environment.
+Use this page to pick versions before you install anything. It lists the current version of every CoFHE package, the toolchain each one requires, and the networks the SDK ships chain definitions for.
 
 <Warning>
-Using incompatible versions of CoFHE components can lead to unexpected behavior, security vulnerabilities, or complete failure of your application. Always verify version compatibility before deployment.
+The `0.7` SDK is not compatible with `0.6` contracts or `0.6` plugins. Upgrading is a breaking change that touches both your Solidity and your client code. See [upgrading from 0.6](#upgrading-from-0-6) before you start.
 </Warning>
 
-## Core Components
+## Which versions to install
 
-The following table lists all core CoFHE components with their current and minimum compatible versions:
+Every `@cofhe/*` package is released from the same monorepo at the same version, and each one pins the others exactly. Keep them all on the same version. Mixing them is the most common cause of a broken install.
 
-| Component | Current Version | Minimum Compatible Version | Notes |
-|-----------|----------------|----------------------------|-------|
-| **@fhenixprotocol/cofhe-contracts** | [`0.1.3`](https://github.com/FhenixProtocol/cofhe-contracts/tree/v0.1.3) | `0.1.3` | Solidity libraries and smart contracts for FHE operations |
-| **@cofhe/sdk** | [`0.5.2`](https://github.com/FhenixProtocol/cofhesdk/releases/tag/v0.5.2) | `0.5.2` | JavaScript library for interacting with FHE contracts and the CoFHE coprocessor |
-| **@cofhe/hardhat-plugin** | `0.5.2` | `0.5.2` | Hardhat plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/hardhat-3-plugin** | `0.5.2` | `0.5.2` | Hardhat 3 plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/foundry-plugin** | `0.5.2` | `0.5.2` | Foundry plugin that deploys mock contracts and exposes utilities |
-| **@cofhe/mock-contracts** | `0.5.2` | `0.5.2` | Mock contracts for local development and testing |
+| Package | Version | What it does |
+| --- | --- | --- |
+| `@cofhe/sdk` | [`0.7.1`](https://github.com/FhenixProtocol/cofhesdk/releases/tag/@cofhe/sdk@0.7.1) | Client library for encrypting inputs, decrypting results, and signing ACPs |
+| `@cofhe/react` | `0.7.1` | React hooks built on the SDK |
+| `@cofhe/abi` | `0.7.1` | ABI definitions for the CoFHE contracts |
+| `@cofhe/hardhat-plugin` | `0.7.1` | Mock deployment and test helpers for Hardhat 2 |
+| `@cofhe/hardhat-3-plugin` | `0.7.1` | Mock deployment and test helpers for Hardhat 3 |
+| `@cofhe/foundry-plugin` | `0.7.1` | Mock deployment and test helpers for Foundry |
+| `@cofhe/mock-contracts` | `0.7.1` | Mock CoFHE contracts for local testing |
 
-## Additional Packages
+Solidity dependencies version separately from the SDK:
 
-These packages provide shared utilities and higher-level abstractions used across the ecosystem:
+| Package | Version | What it does |
+| --- | --- | --- |
+| `@fhenixprotocol/cofhe-contracts` | [`0.2.0`](https://github.com/FhenixProtocol/cofhe-contracts/tree/v0.2.0) | `FHE.sol` and the onchain CoFHE interfaces |
+| `@fhenixprotocol/cofhe-errors` | `1.0.2` | Shared error definitions for the CoFHE contracts |
+| `fhenix-confidential-contracts` | `0.4.0` | Confidential token primitives, including FHERC20 |
 
-| Component | Current Version | Minimum Compatible Version | Notes |
-|-----------|----------------|----------------------------|-------|
-| **@fhenixprotocol/cofhe-errors** | `1.0.2` | `1.0.2` | Shared error definitions for CoFHE contracts |
-| **@fhenixprotocol/fhenix-confidential-contracts** | `0.2.1` | `0.2.1` | Pre-built confidential contract primitives (FHERC20, etc.) |
+<Note>
+`fhenix-confidential-contracts` is published unscoped. There is no `@fhenixprotocol/fhenix-confidential-contracts` package, so installing that name fails.
+</Note>
 
-### Version Compatibility Guidelines
+## What each package requires
 
-When working with CoFHE components:
+These are the peer dependencies declared by the published packages.
 
-- **Always use the latest stable versions**: Check GitHub releases for the most recent versions
-- **Verify compatibility**: Ensure all components are within their compatible version ranges
-- **Test thoroughly**: After updating versions, test your application in both mock and testnet environments
-- **Check release notes**: Review breaking changes and migration guides when upgrading
+| Package | Required | Optional |
+| --- | --- | --- |
+| `@cofhe/sdk` | `viem` ^2.38.6 | `ethers` ^5 or ^6, `@wagmi/core` ^2, `hardhat` ^2, `@nomicfoundation/hardhat-ethers` ^3 |
+| `@cofhe/hardhat-plugin` | `hardhat` ^2, `@nomicfoundation/hardhat-ethers` ^3, `ethers` ^5 or ^6, `@fhenixprotocol/cofhe-contracts` >=0.2.0, `@openzeppelin/contracts` ^5 | None |
+| `@cofhe/hardhat-3-plugin` | `hardhat` ^3 | None |
+| `@cofhe/foundry-plugin` | `@fhenixprotocol/cofhe-contracts` 0.2.0, `@openzeppelin/contracts` 5.4.0 | None |
 
-<Tip>
-For the best development experince, use the latest versions of all components. They are designed to work together seamlessly and include the latest features and security improvements.
-</Tip>
+`viem` is the only client library the SDK always needs. The optional entries are adapters: install `ethers` or `@wagmi/core` only if you want to pass those objects to the SDK.
 
-## Network Compatibility
+Pick your Hardhat plugin by the Hardhat version you already run: `@cofhe/hardhat-plugin` for Hardhat 2, `@cofhe/hardhat-3-plugin` for Hardhat 3. They are not interchangeable.
 
-CoFHE currently supports the following networks:
+## Supported networks
 
-| Network | Compatible | API Version | Notes | Plugin Name |
-|---------|------------|-------------|-------|-------------|
-| **Sepolia** | ✅ | `v1` | Full support | `eth-sepolia` |
-| **Arbitrum Sepolia** | ✅ | `v1` | Full support | `arb-sepolia` |
-| **Base Sepolia** | ✅ | `v1` | Full support | `base-sepolia` |
+The SDK ships chain definitions for these networks, exported from `@cofhe/sdk/chains`:
 
-<Info>
-All supported networks use API version `v1`. The plugin names correspond to the network identifiers used in Hardhat configuration files.
-</Info>
-
-
-## Troubleshooting Compatibility Issues
-
-If you encounter compatibility issues:
-
-1. **Verify all versions**: Ensure all CoFHE components are using compatible versions
-2. **Check network support**: Confirm your target network is supported
-3. **Review error messages**: Look for version mismatch errors in your console
-4. **Update dependencies**: Run `npm update` or `yarn upgrade` to get the latest compatible versions
-5. **Check documentation**: Review the component-specific documentation for version requirements
+| Network | Chain ID | SDK export | Hardhat preset |
+| --- | --- | --- | --- |
+| Ethereum Sepolia | `11155111` | `sepolia` | `eth-sepolia` |
+| Arbitrum Sepolia | `421614` | `arbSepolia` | `arb-sepolia` |
+| Base Sepolia | `84532` | `baseSepolia` | None |
+| Local CoFHE | `420105` | `localcofhe` | `localcofhe` |
+| Hardhat (mock) | `31337` | `hardhat` | Built into Hardhat |
 
 <Warning>
-If you're experiencing issues after updating versions, check the release notes for breaking changes and migration guides. Some updates may require code changes in your contracts or client applications.
+The SDK export name and the Hardhat preset name are different strings for the same network. The SDK calls Ethereum Sepolia `sepolia`; both Hardhat plugins register the preset as `eth-sepolia`. Use the SDK name in client code and the preset name in `hardhat.config.ts`.
 </Warning>
 
-## Next Steps
+Base Sepolia has no Hardhat preset in either plugin. To deploy there, add the network yourself:
 
-- Review the [Quick Start guide](/fhe-library/introduction/quick-start) to set up your development environment
-- Learn about [best practices](/fhe-library/introduction/best-practices) for developing with CoFHE
-- Explore the [API reference](/api-reference/introduction) for detailed component documentation
+```typescript hardhat.config.ts
+networks: {
+  'base-sepolia': {
+    url: process.env.BASE_SEPOLIA_RPC_URL ?? 'https://sepolia.base.org',
+    accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+    chainId: 84532,
+  },
+},
+```
+
+## Upgrading from 0.6 {#upgrading-from-0-6}
+
+Upgrade to `0.6.1` first, then to `0.7.1`. The `0.7` release changes four things that will break a `0.6` project:
+
+- Permits are renamed to ACPs. The `@cofhe/sdk/permits` entry point is now `@cofhe/sdk/acps`.
+- The `InEuintXX` input types are gone, along with `FHE.asEuint32(InEuint32)` and `ITaskManager.verifyInput`.
+- Signing moved from one signature per ciphertext to one signature per batch, which requires a `setConsumingContract()` call.
+- Encrypted values passed between contracts now use the `sharedEuintXX` types instead of bare `euintXX`.
+
+Permits signed under `0.6` stop working. Your users have to sign again after you upgrade.
+
+The [official migration guide](https://cofhesdk.fhenix.io/migrating-to-0-7-0) covers each change with before and after code. It also ships an agent skill that performs most of the mechanical edits for you.
+
+## Troubleshooting
+
+<AccordionGroup>
+<Accordion title="Install fails on @fhenixprotocol/fhenix-confidential-contracts" icon="circle-xmark">
+That package name does not exist. Install `fhenix-confidential-contracts` instead, without the scope.
+</Accordion>
+
+<Accordion title="Hardhat cannot find the eth-sepolia network" icon="network-wired">
+Both plugins register `eth-sepolia` only when your own config does not already define it. Confirm the plugin is imported in `hardhat.config.ts`, and that you are not shadowing the preset with an empty entry of the same name.
+</Accordion>
+
+<Accordion title="Encrypted inputs stop verifying after upgrading" icon="key">
+`0.7` signs one batch rather than one ciphertext, and the input types changed. A `0.6` client against `0.7` contracts fails verification. Upgrade both sides together.
+</Accordion>
+</AccordionGroup>
+
+## Next steps
+
+- Follow the [quick start guide](/fhe-library/introduction/quick-start) to set up a development environment.
+- Read the [best practices](/fhe-library/introduction/best-practices) for building with CoFHE.
+- Browse the [API reference](/api-reference/introduction) for per-component detail.


### PR DESCRIPTION
First branch of the 0.7 version-update series. Scope is deliberately one page: the compatibility matrix integrators use to pick versions.

## What was wrong

Every version on the page was stale, and three entries were not just old but incorrect. All findings verified against npm and the published tarballs, not from memory.

| Claim on the page | Reality |
|---|---|
| `@cofhe/sdk` and all plugins `0.5.2` | `0.7.1` |
| `@fhenixprotocol/cofhe-contracts` `0.1.3` | `0.2.0` |
| SDK link `releases/tag/v0.5.2` | **404s.** cofhesdk is a monorepo tagged per package (`@cofhe/sdk@0.7.1`), so `v*` tags never existed |
| `@fhenixprotocol/fhenix-confidential-contracts` `0.2.1` | **No such package.** It is `fhenix-confidential-contracts`, unscoped, at `0.4.0` |
| Base Sepolia preset `base-sepolia` | **Not registered by either Hardhat plugin.** Both ship `localcofhe`, `eth-sepolia`, `arb-sepolia` only |
| "API Version `v1`" for every network | **No such concept in the SDK.** The chain schema is `id`, `name`, `network`, three service URLs, and `environment` |

The last two are the ones most likely to have cost someone an afternoon.

## What changed

Versions and links refreshed, both new links checked for a 200. `@cofhe/react` and `@cofhe/abi` added, since both ship at `0.7.1` and were missing entirely.

**The network table now separates the SDK export from the Hardhat preset.** They are different strings for the same network, which the old single "Plugin Name" column hid: the SDK calls Ethereum Sepolia `sepolia` while both plugins register `eth-sepolia`. Base Sepolia is listed with no preset and a config snippet to add it.

**Peer dependencies added.** This is what actually decides whether a reader needs `hardhat-plugin` (Hardhat ^2) or `hardhat-3-plugin` (Hardhat ^3), and the page never said. Required and optional are split, because `viem` is the SDK's only mandatory client library while `ethers`, `@wagmi/core`, and `hardhat` are optional adapters.

**Upgrade section added** pointing at the [0.6 to 0.7 migration guide](https://cofhesdk.fhenix.io/migrating-to-0-7-0), listing the four breaking changes and the fact that `0.6` permits stop working and users must re-sign.

The generic troubleshooting list ("run `npm update`") is replaced with the three failure modes this page's own errors would produce.

## Two things I did not do

**The staging chain is deliberately omitted.** `@cofhe/sdk/chains` also exports `stagingCofhe`, but STYLE.md forbids internal hostnames and environment names in public docs, and that entry carries both.

**Network support still needs owner verification.** I documented what the SDK source ships, and worded it as "the SDK ships chain definitions for" rather than "CoFHE supports". Whether the deployed services actually serve all three testnets today is not answerable from source: all three point at the same `coFheUrl`. If you confirm the real list, I will tighten the wording.

Vale, `lint-docs.py`, `mint validate`, and `mint broken-links --check-anchors` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)